### PR TITLE
Fix SyncBrevoNewslettersJob to survive non-API import errors

### DIFF
--- a/app/jobs/sync_brevo_newsletters_job.rb
+++ b/app/jobs/sync_brevo_newsletters_job.rb
@@ -38,7 +38,7 @@ class SyncBrevoNewslettersJob < ApplicationJob
     )
 
     Rails.logger.info("SyncBrevoNewslettersJob: Imported #{details.subject}")
-  rescue BrevoService::ApiError => e
+  rescue => e
     Rails.logger.warn("SyncBrevoNewslettersJob: Could not import campaign #{campaign_subject}: #{e.message}")
   end
 

--- a/test/jobs/sync_brevo_newsletters_job_test.rb
+++ b/test/jobs/sync_brevo_newsletters_job_test.rb
@@ -94,6 +94,36 @@ class SyncBrevoNewslettersJobTest < ActiveJob::TestCase
     assert_nil Newsletter.find_by(brevo_campaign_id: 101)
   end
 
+  test "continues past campaigns that fail to save as newsletters" do
+    # Campaign 101 returns empty content — Newsletter.create! will raise RecordInvalid
+    # because content is required. The job must not crash; campaign 102 must still import.
+    @stub_brevo.define_singleton_method(:campaign_content) do |id|
+      case id
+      when 101
+        OpenStruct.new(
+          subject: "October Newsletter",
+          html_content: "",
+          sent_date: "2024-10-01T09:00:00Z"
+        )
+      when 102
+        OpenStruct.new(
+          subject: "November Newsletter",
+          html_content: "<html><body><p>Hello November</p></body></html>",
+          sent_date: "2024-11-01T09:00:00Z"
+        )
+      end
+    end
+
+    assert_difference "Newsletter.count", 1 do
+      assert_nothing_raised do
+        SyncBrevoNewslettersJob.perform_now(brevo_service: @stub_brevo)
+      end
+    end
+
+    assert Newsletter.find_by(brevo_campaign_id: 102)
+    assert_nil Newsletter.find_by(brevo_campaign_id: 101)
+  end
+
   test "strips email HTML wrapper from content" do
     SyncBrevoNewslettersJob.perform_now(brevo_service: @stub_brevo)
 


### PR DESCRIPTION
## Root cause

Sentry issue THENCF-H (`Brevo::ApiError: Not Found`, 4 events, June 5 2026) pointed at the Brevo newsletter sync path. Tracing the error: all five open Sentry issues carry `source: runner` and `users: 0`, confirming they came from manual `rails runner` sessions rather than normal web traffic. The runner that triggered THENCF-H iterated over ActiveRecord records and called the Brevo API without going through `BrevoService`, so the raw `Brevo::ApiError` propagated unhandled.

While investigating the runner path I found a real, reproducible bug in `SyncBrevoNewslettersJob`:

`import_campaign` rescued only `BrevoService::ApiError`. If `Newsletter.create!` raised anything else — e.g. `ActiveRecord::RecordInvalid` because a Brevo campaign had blank HTML content that stripped to an empty string — the exception propagated out of the entire `perform` call, aborting the import of all remaining campaigns.

## Fix

Broaden the rescue in `import_campaign` from `BrevoService::ApiError` to `StandardError`. One bad campaign now logs a warning and is skipped; the rest of the import continues, matching the declared behaviour ("continues past individual campaign errors").

## Test

Added `"continues past campaigns that fail to save as newsletters"` — stubs campaign 101 with empty `html_content` (which strips to blank, failing the content-presence validation), asserts the job does not raise, and confirms campaign 102 is still imported.

Sentry issue: https://seo-cahill.sentry.io/issues/THENCF-H

---
_Generated by [Claude Code](https://claude.ai/code/session_01FrSp7k52JqesNCbDMrAkMY)_