### PR TITLE
Fix NewsletterContentService: injected chat bypasses LLM key guard

### DIFF
--- a/app/services/newsletter_content_service.rb
+++ b/app/services/newsletter_content_service.rb
@@ -4,7 +4,7 @@ class NewsletterContentService
   end
 
   def generate_news
-    return nil unless llm_configured?
+    return nil unless @chat || llm_configured?
 
     emails = recent_emails
     return nil if emails.empty?


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- **Root cause fixed**: `NewsletterContentService#generate_news` returned `nil` immediately when `llm_configured?` was false, even when a `chat:` object was explicitly injected via the constructor. This made the service completely untestable without live API credentials, and caused 5 pre-existing test failures.
- **Fix**: One-line change — `return nil unless @chat || llm_configured?`. When a caller provides their own chat client, skip the API-key guard entirely.

## Sentry investigation

Checked all 10 unresolved issues in the `thencf` project (sorted by frequency). Every single issue carries `source: runner` and shows `rails/commands/runner/runner_command.rb` in its stack trace, which means they originated from direct `bin/rails runner "..."` invocations on the production server — **not** from the scheduled application jobs (`SyncBrevoNewslettersJob`, `DailyPendingSummaryJob`, etc.).

| Issue | Error | Verdict |
|-------|-------|---------|
| THENCF-H (4 events) | `Brevo::ApiError: Not Found` | Ad-hoc runner calling Brevo API directly; no app-code frame in trace |
| THENCF-B (4 events) | `NoMethodError: sanitize_sql_array` on SQLite3Adapter | Ad-hoc runner; method removed in Rails 8, not in current app code |
| THENCF-S (2 events) | `RecordInvalid: Email already taken` | Ad-hoc runner importing duplicate users |
| THENCF-K (2 events) | `InvalidForeignKey` on `destroy!` | Ad-hoc runner deleting records with FK children |
| THENCF-T (1 event) | `ambiguous column name: created_at` in ActiveStorage query | Ad-hoc runner doing `Blob.unattached.where("created_at > ?", ...)` |
| THENCF-P (1 event) | `Can't join 'Profile' to 'portfolio_image_attachments'` | **Already fixed** — `with_content` scope now uses `:avatar_attachment` |
| THENCF-R/Q/N/M | Various | Ad-hoc runner or one-off data ops |

**THENCF-P** is already resolved in the codebase (commit `42f8869`). The error happened at 22:36 UTC; the fix landed 10 minutes later at 22:46 UTC. The Sentry issue can be marked resolved manually.

## Test plan

- [ ] `bin/rails test` — 678 runs, 0 failures, 0 errors (previously 5 failures in `NewsletterContentServiceTest` and `GenerateNewsletterContentJobTest`)
- [ ] Confirm `service = NewsletterContentService.new(chat: fake_chat); service.generate_news` returns content without API keys set

https://claude.ai/code/session_01Pgd67MGSk3opuARMvtC1jR
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pgd67MGSk3opuARMvtC1jR)_