### PR TITLE
Fix NewsletterContentService ignoring injected chat; Sentry issue triage

### DIFF
--- a/app/services/newsletter_content_service.rb
+++ b/app/services/newsletter_content_service.rb
@@ -4,7 +4,7 @@ class NewsletterContentService
   end
 
   def generate_news
-    return nil unless llm_configured?
+    return nil unless @chat || llm_configured?
 
     emails = recent_emails
     return nil if emails.empty?


### PR DESCRIPTION
## Summary

- Fixes 5 pre-existing test failures in `NewsletterContentService` and `GenerateNewsletterContentJob`
- Documents findings from Sentry issue triage (org `seo-cahill`, project `thencf`)

---

## Bug fix: `NewsletterContentService` ignores injected chat

### Root cause

`generate_news` had this guard:

```ruby
return nil unless llm_configured?
```

`llm_configured?` only checks environment API keys (`mistral_api_key`, `openai_api_key`, `anthropic_api_key`). It returned `false` even when a chat was explicitly injected via `new(chat: fake_chat)`, causing the method to return `nil` before using the injected object.

This broke 5 tests that inject a fake chat for isolation.

### Fix

```ruby
return nil unless @chat || llm_configured?
```

If a chat is explicitly provided, skip the API key check. The injected chat is the LLM.

---

## Sentry triage findings

I investigated all 5 unresolved high-priority issues. **All 5 have `source: runner` and 0 users impacted.** They appear to be from manual `rails runner` commands run on June 5–6, not from the application serving requests.

| Issue | Error | Events |
|-------|-------|--------|
| THENCF-B (regressed) | `NoMethodError: sanitize_sql_array` on `SQLite3Adapter` | 4 |
| THENCF-H | `Brevo::ApiError: Not Found` from `get_email_campaign` | 4 |
| THENCF-S | `RecordInvalid: Email address has already been taken` | 2 |
| THENCF-K | `InvalidForeignKey: FOREIGN KEY constraint failed` on `destroy!` | 2 |
| THENCF-T | `StatementInvalid: ambiguous column name: created_at` in Active Storage query | 1 |

**THENCF-B** is the most concerning (4 events, regressed). The error is `undefined method 'sanitize_sql_array' for an instance of ActiveRecord::ConnectionAdapters::SQLite3Adapter`. `sanitize_sql_array` is a class method on `ActiveRecord::Base` — calling it on a connection object is wrong. I searched the entire codebase and **could not find this call anywhere in the repository**. It must be from a script or runner command not checked in.

**THENCF-T** is a real SQL bug: `WHERE (created_at > ?)` is ambiguous when `active_storage_blobs` is JOINed with `active_storage_attachments` (both have `created_at`). The fix is to qualify: `active_storage_blobs.created_at`. Again, the query generating this is **not in the repository** — it was likely run as a one-off maintenance command.

**THENCF-H, THENCF-S, THENCF-K** are all operational errors (wrong campaign ID, email uniqueness collision, FK constraint) from runner scripts, not application bugs.

### What I could not do

Because the code for THENCF-B and THENCF-T doesn't exist in the repo, I could not write failing tests or fix the root cause. If these are from recurring cron scripts or kamal run commands outside the repo, please point me to them.

https://claude.ai/code/session_01P5UUq4izjiVLQUN49Uz2C7

---
_Generated by [Claude Code](https://claude.ai/code/session_01P5UUq4izjiVLQUN49Uz2C7)_