### PR TITLE
Fix ambiguous created_at column in Active Storage unattached blob query

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     brevo (4.0.0)
       addressable (~> 2.3, >= 2.3.0)
@@ -681,7 +681,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   brevo (4.0.0) sha256=016aff0108a8c90b55bbc414a30900f796c654ebc5d79c857d9b5fb37606fd05
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/app/jobs/cleanup_orphaned_blobs_job.rb
+++ b/app/jobs/cleanup_orphaned_blobs_job.rb
@@ -1,0 +1,12 @@
+class CleanupOrphanedBlobsJob < ApplicationJob
+  queue_as :default
+
+  ORPHAN_AGE = 1.day
+
+  def perform
+    ActiveStorage::Blob
+      .unattached
+      .where("active_storage_blobs.created_at < ?", ORPHAN_AGE.ago)
+      .find_each(&:purge)
+  end
+end

--- a/test/jobs/cleanup_orphaned_blobs_job_test.rb
+++ b/test/jobs/cleanup_orphaned_blobs_job_test.rb
@@ -1,0 +1,49 @@
+require "test_helper"
+
+class CleanupOrphanedBlobsJobTest < ActiveJob::TestCase
+  test "does not raise ambiguous column error when querying unattached blobs" do
+    assert_nothing_raised do
+      CleanupOrphanedBlobsJob.perform_now
+    end
+  end
+
+  test "purges blobs older than one day that are not attached to any record" do
+    blob = create_blob("old_orphan.txt")
+
+    travel_to(2.days.from_now) do
+      assert_difference "ActiveStorage::Blob.count", -1 do
+        CleanupOrphanedBlobsJob.perform_now
+      end
+    end
+  end
+
+  test "does not purge recently created unattached blobs" do
+    create_blob("new_orphan.txt")
+
+    assert_no_difference "ActiveStorage::Blob.count" do
+      CleanupOrphanedBlobsJob.perform_now
+    end
+  end
+
+  test "does not purge attached blobs older than one day" do
+    profile = profiles(:owner_profile)
+    blob = create_blob("attached.txt")
+    profile.avatar.attach(blob)
+
+    travel_to(2.days.from_now) do
+      assert_no_difference "ActiveStorage::Blob.count" do
+        CleanupOrphanedBlobsJob.perform_now
+      end
+    end
+  end
+
+  private
+
+  def create_blob(filename)
+    ActiveStorage::Blob.create_and_upload!(
+      io: StringIO.new("content"),
+      filename: filename,
+      content_type: "text/plain"
+    )
+  end
+end


### PR DESCRIPTION
$(cat <<'EOF'
## Summary

- Fixes Sentry issue [THENCF-T](https://seo-cahill.sentry.io/issues/THENCF-T): `SQLite3::SQLException: ambiguous column name: created_at`
- Adds `CleanupOrphanedBlobsJob` that implements orphaned-blob cleanup with a properly table-qualified SQL column reference
- Replaces the ad-hoc `bin/rails runner` invocations that triggered the error with a testable, schedulable job

## Root cause

The error occurred when querying `ActiveStorage::Blob.unattached` with a raw SQL `WHERE` clause on `created_at`:

```ruby
ActiveStorage::Blob.unattached.where("created_at > ?", some_time)
```

`ActiveStorage::Blob.unattached` generates a `LEFT OUTER JOIN` between `active_storage_blobs` and `active_storage_attachments`. Both tables have a `created_at` column, so SQLite raises:

```
SQLite3::SQLException: ambiguous column name: created_at
```

The fix is to qualify the column with its table name:

```ruby
ActiveStorage::Blob.unattached.where("active_storage_blobs.created_at < ?", 1.day.ago)
```

## What changed

Added `CleanupOrphanedBlobsJob` — a standard ApplicationJob that finds unattached blobs older than 1 day and purges them. This is the correct way to run this cleanup instead of ad-hoc runner scripts.

To schedule it, add to `config/recurring.yml`:

```yaml
cleanup_orphaned_blobs:
  class: CleanupOrphanedBlobsJob
  queue: default
  schedule: every day at 4am
```

## Test plan

- [ ] `bin/rails test test/jobs/cleanup_orphaned_blobs_job_test.rb` — 4 tests, all green
- [ ] `bin/rails test` — no regressions (5 pre-existing failures in `NewsletterContentServiceTest` / `GenerateNewsletterContentJobTest` are unrelated)

https://claude.ai/code/session_01FfpDBCKsvNCMdGuBuUiRZB
EOF
)

---
_Generated by [Claude Code](https://claude.ai/code/session_01FfpDBCKsvNCMdGuBuUiRZB)_