### PR TITLE
Fix NewsletterContentService blocking injected chat + Sentry investigation

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     brevo (4.0.0)
       addressable (~> 2.3, >= 2.3.0)
@@ -681,7 +681,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   brevo (4.0.0) sha256=016aff0108a8c90b55bbc414a30900f796c654ebc5d79c857d9b5fb37606fd05
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
     mustache (1.1.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -761,7 +761,7 @@ CHECKSUMS
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mustache (1.1.1) sha256=90891fdd50b53919ca334c8c1031eada1215e78d226d5795e523d6123a2717d0
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d

--- a/app/services/newsletter_content_service.rb
+++ b/app/services/newsletter_content_service.rb
@@ -19,7 +19,8 @@ class NewsletterContentService
   private
 
   def llm_configured?
-    RubyLLM.config.mistral_api_key.present? ||
+    @chat.present? ||
+      RubyLLM.config.mistral_api_key.present? ||
       RubyLLM.config.openai_api_key.present? ||
       RubyLLM.config.anthropic_api_key.present?
   end


### PR DESCRIPTION
## Summary

- Fixes `NewsletterContentService#llm_configured?` ignoring an already-injected `@chat` object, which caused 5 test failures after the June 8 refactor
- Documents a thorough Sentry investigation: all 5 open issues trace to ad-hoc `rails runner` maintenance scripts, not the committed application code

---

## The Code Fix

**Root cause:** `generate_news` gates on `llm_configured?` before using the chat. That check only inspects API key env vars — it never considers whether the caller already injected a configured `@chat`. In the test environment (and any DI scenario) this short-circuits to `nil` immediately, making the tests pass silently for the wrong reason and preventing real generation/broadcast paths from being exercised.

**Fix:** Add `@chat.present?` as the first condition in `llm_configured?`. A provided chat means the caller has already handled configuration; no API-key check needed.

```ruby
def llm_configured?
  @chat.present? ||                                    # ← added
    RubyLLM.config.mistral_api_key.present? ||
    RubyLLM.config.openai_api_key.present? ||
    RubyLLM.config.anthropic_api_key.present?
end
```

**Tests fixed (5 failures → 0):**
- `NewsletterContentServiceTest#test_generates_news_section_from_cached_emails`
- `NewsletterContentServiceTest#test_excludes_archived_emails`
- `NewsletterContentServiceTest#test_strips_code_fences_from_LLM_response`
- `GenerateNewsletterContentJobTest#test_replaces_news_placeholder_with_generated_content`
- `GenerateNewsletterContentJobTest#test_broadcasts_refresh_to_newsletter_stream`

Full suite: **678 runs, 0 failures, 0 errors** ✓

---

## Sentry Investigation

Checked the 5 open issues in project `thencf` (sorted by frequency). All have `source: runner` and `mechanism: rails`, meaning every single one originated from a `rails runner` command — not from a web request, background job, or rake task. None are in the committed application code.

### THENCF-H — `Brevo::ApiError: Not Found` (4 events, highest frequency)
https://seo-cahill.sentry.io/issues/THENCF-H

The raw `Brevo::ApiError` (not wrapped as `BrevoService::ApiError`) is reaching Sentry. Every application path that calls `get_email_campaign` goes through `BrevoService#campaign_content` or `#campaign_status`, both of which rescue `Brevo::ApiError` and re-raise as `BrevoService::ApiError`. The only way the raw error surfaces is if the runner script calls the Brevo gem API client directly, bypassing the service layer entirely (e.g. `Brevo::EmailCampaignsApi.new.get_email_campaign(some_id)`). The campaign ID requested doesn't exist in Brevo (404).

**Fix needed (in the runner script):** Route through `BrevoService#campaign_content` or `#campaign_status`, which wraps the error. Alternatively, add a `rescue Brevo::ApiError` in the script.

### THENCF-B — `SystemExit: exit` caused by `NoMethodError: undefined method 'sanitize_sql_array' for an instance of ActiveRecord::ConnectionAdapters::SQLite3Adapter` (4 events)
https://seo-cahill.sentry.io/issues/THENCF-B

`sanitize_sql_array` is a class-level method on `ActiveRecord::Base`, not an instance method on the connection adapter. The runner script is calling `some_model.connection.sanitize_sql_array(...)` instead of `SomeModel.sanitize_sql_array(...)`. The `NoMethodError` bubbles to the runner's outer rescue → `exit 1` → `SystemExit`.

**Fix needed (in the runner script):** `SomeModel.sanitize_sql_array([...])` instead of `connection.sanitize_sql_array([...])`.

### THENCF-S — `ActiveRecord::RecordInvalid: Email address has already been taken` (2 events)
https://seo-cahill.sentry.io/issues/THENCF-S

Unhandled `User.create!` with a duplicate email in a runner script. `SyncBrevoContactsJob#sync_contact_to_local` already rescues `ActiveRecord::RecordInvalid`, but this error is not going through the job — it's from a raw script that doesn't have a rescue block.

**Fix needed (in the runner script):** Add `rescue ActiveRecord::RecordInvalid` or use `find_or_create_by!`.

### THENCF-K — `ActiveRecord::InvalidForeignKey: FOREIGN KEY constraint failed` (2 events)
https://seo-cahill.sentry.io/issues/THENCF-K

A runner script calls `SomeRecord.find(id).destroy!` on a record that has dependent records not cascaded at the DB level. The stack goes through `active_record/persistence.rb:470 destroy!` → `_delete_row` → SQLite FK error.

**Fix needed (in the runner script):** Destroy dependents first, or use `dependent: :destroy` if the association is missing it, or call `destroy` (not `destroy!`) and check the return value.

### THENCF-T — `SQLite3::SQLException: ambiguous column name: created_at` (1 event)
https://seo-cahill.sentry.io/issues/THENCF-T

Query: `SELECT "active_storage_blobs".* FROM "active_storage_blobs" LEFT OUTER JOIN "active_storage_attachments" ... WHERE (created_at > ?) AND "active_storage_attachments"."id" IS NULL`

This is `ActiveStorage::Blob.unattached.where("created_at > ?", time)`. The `unattached` scope does a LEFT JOIN with `active_storage_attachments`, making `created_at` ambiguous. Also note `>` instead of `<` — this query finds *recent* unattached blobs, not old ones, which is unusual for a cleanup script.

**Fix needed (in the runner script):** Qualify the column: `where("active_storage_blobs.created_at > ?", time)`. Also consider using `ActiveStorage::Blob.unattached.where(active_storage_blobs: { created_at: time.. }).purge_later` which uses the Rails-aware `purge` path.

---

## Test plan

- [x] `bin/rails test test/services/newsletter_content_service_test.rb` — all pass
- [x] `bin/rails test test/jobs/generate_newsletter_content_job_test.rb` — all pass
- [x] `bin/rails test` — 678 runs, 0 failures

https://claude.ai/code/session_01MvPBpjfhidWZZ5LxYhryvi

---
_Generated by [Claude Code](https://claude.ai/code/session_01MvPBpjfhidWZZ5LxYhryvi)_