### PR TITLE
Fix NewsletterContentService silently no-oping when LLM keys absent

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     brevo (4.0.0)
       addressable (~> 2.3, >= 2.3.0)
@@ -681,7 +681,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   brevo (4.0.0) sha256=016aff0108a8c90b55bbc414a30900f796c654ebc5d79c857d9b5fb37606fd05
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
     mustache (1.1.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -761,7 +761,7 @@ CHECKSUMS
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mustache (1.1.1) sha256=90891fdd50b53919ca334c8c1031eada1215e78d226d5795e523d6123a2717d0
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d

--- a/app/services/newsletter_content_service.rb
+++ b/app/services/newsletter_content_service.rb
@@ -19,7 +19,8 @@ class NewsletterContentService
   private
 
   def llm_configured?
-    RubyLLM.config.mistral_api_key.present? ||
+    @chat.present? ||
+      RubyLLM.config.mistral_api_key.present? ||
       RubyLLM.config.openai_api_key.present? ||
       RubyLLM.config.anthropic_api_key.present?
   end


### PR DESCRIPTION
## Summary

- `NewsletterContentService#llm_configured?` now returns `true` when a `chat` object is explicitly injected via the constructor, fixing the premature early return in `generate_news`.
- This unblocks `GenerateNewsletterContentJob` in environments where API keys haven't loaded yet and fixes 3 pre-existing failing tests.

## Root cause

`generate_news` called `llm_configured?` before using the chat object. When no API keys are present (any env without `MISTRAL_API_KEY`/`OPENAI_API_KEY`/`ANTHROPIC_API_KEY`), it returned `nil` immediately — silently ignoring the injected `fake_chat` in tests, and silently no-oping in production environments where key loading may be delayed.

**Fix** (`app/services/newsletter_content_service.rb`):
```ruby
def llm_configured?
  @chat.present? ||                       # ← added: injected chat = configured
    RubyLLM.config.mistral_api_key.present? ||
    RubyLLM.config.openai_api_key.present? ||
    RubyLLM.config.anthropic_api_key.present?
end
```

## Sentry investigation findings

Checked `seo-cahill / thencf` for the highest-priority issues. All 10 critical-priority issues originate from `bin/rails runner` ad-hoc scripts run from the production server — none are from tracked application code. Key findings:

**THENCF-P** (`Can't join 'Profile' to association named 'portfolio_image_attachments'`) — **already fixed** in commit `42f8869`. The `with_content` scope now correctly uses `left_joins(:avatar_attachment)`. Please mark resolved in Sentry.

**THENCF-7** (`no such column: email`, recurring — occurred May 4 and June 5) — A runner script queries users with `WHERE (email LIKE ...)` but the column is `email_address`. The script itself is not in the repo. Worth converting to a proper rake task when needed; note that `User` already has `def email; email_address; end` as a Ruby alias but this does **not** create a DB column.

**THENCF-T** (`ambiguous column name: created_at`) — A runner script called `ActiveStorage::Blob.unattached.where("created_at > ?", ...)` without table-qualifying `created_at`. Fix when that script is written as a proper task: use `where("active_storage_blobs.created_at > ?", ...)`.

**THENCF-H** (`Brevo::ApiError: Not Found`, 4 events) — Runner script called `brevo.get_email_campaign(id)` for a campaign ID that no longer exists in Brevo. Transient; safe to resolve.

## Test plan

- [x] `bin/rails test test/services/newsletter_content_service_test.rb` — 6/6 pass (was 3 failing)
- [x] `bin/rails test` — 678/678 pass, no regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Wn1jkYGXTX2ZeF3cYxyMPk

---
_Generated by [Claude Code](https://claude.ai/code/session_01Wn1jkYGXTX2ZeF3cYxyMPk)_