### PR TITLE
Fix NewsletterContentService ignoring injected chat dependency

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     brevo (4.0.0)
       addressable (~> 2.3, >= 2.3.0)
@@ -681,7 +681,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   brevo (4.0.0) sha256=016aff0108a8c90b55bbc414a30900f796c654ebc5d79c857d9b5fb37606fd05
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
     mustache (1.1.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -761,7 +761,7 @@ CHECKSUMS
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mustache (1.1.1) sha256=90891fdd50b53919ca334c8c1031eada1215e78d226d5795e523d6123a2717d0
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d

--- a/app/services/newsletter_content_service.rb
+++ b/app/services/newsletter_content_service.rb
@@ -4,7 +4,7 @@ class NewsletterContentService
   end
 
   def generate_news
-    return nil unless llm_configured?
+    return nil if @chat.nil? && !llm_configured?
 
     emails = recent_emails
     return nil if emails.empty?


### PR DESCRIPTION
## Summary

- Fix `NewsletterContentService#generate_news` returning `nil` when a chat was explicitly injected but no LLM API keys were configured
- This caused 5 test failures in `NewsletterContentServiceTest` and `GenerateNewsletterContentJobTest`

## Root Cause

`generate_news` had an early return guarded by `llm_configured?` regardless of whether a chat object was injected:

```ruby
# Before
def generate_news
  return nil unless llm_configured?  # always nil in test env — even with injected chat
  ...
end
```

When a fake chat was passed via `NewsletterContentService.new(chat: fake_chat)`, the method returned `nil` immediately because no real LLM API keys are set in the test environment, making the service impossible to test without live credentials.

**Fix:** Only enforce the configured guard when no chat has been provided. An explicitly injected chat bypasses the check:

```ruby
# After
def generate_news
  return nil if @chat.nil? && !llm_configured?
  ...
end
```

This preserves the intended "return nil if unconfigured" behaviour for the default (no injection) path while allowing dependency injection to work as designed.

## Sentry Issue Analysis

Checked Sentry org `seo-cahill`, project `thencf`. Found 5 unresolved issues, all tagged `source: runner` (i.e. originated from `bin/rails runner` commands, not web requests or background jobs):

| Issue | Error | Events | Last seen |
|-------|-------|--------|-----------|
| THENCF-H | `Brevo::ApiError: Not Found` | 4 | 12 days ago |
| THENCF-B | `NoMethodError: sanitize_sql_array on SQLite3Adapter` | 4 | 12 days ago |
| THENCF-S | `ActiveRecord::RecordInvalid: Email already taken` | 2 | 12 days ago |
| THENCF-K | `ActiveRecord::InvalidForeignKey` | 2 | 12 days ago |
| THENCF-T | `ActiveRecord::StatementInvalid: ambiguous column name: created_at` | 1 | 12 days ago |

All appear to be from an ad-hoc maintenance session on June 5–6. None of the errors are present in application code:

- **THENCF-B** (`sanitize_sql_array` on a connection adapter) — this method doesn't exist in the codebase; someone called it on an AR connection object in a one-off script
- **THENCF-T** (ambiguous `created_at` in ActiveStorage JOIN) — the pattern `ActiveStorage::Blob.unattached.where("created_at > ?", t)` is not in application code; fix would be to qualify as `active_storage_blobs.created_at`
- **THENCF-H**, **THENCF-S**, **THENCF-K** — database/API errors from maintenance scripts without proper error handling

The `SyncBrevoNewslettersJob` (runs Mondays at 8am) correctly wraps `Brevo::ApiError` into `BrevoService::ApiError` and handles it per-campaign; THENCF-H occurred on a Friday, confirming it was a manual runner session.

## Test Plan

- [x] `bin/rails test test/services/newsletter_content_service_test.rb` — 6/6 pass
- [x] `bin/rails test test/jobs/generate_newsletter_content_job_test.rb` — 4/4 pass
- [x] `bin/rails test` — 678 tests, 0 failures, 0 errors

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Pq8hDFm3qnWWVBWWDgfKuf

---
_Generated by [Claude Code](https://claude.ai/code/session_01Pq8hDFm3qnWWVBWWDgfKuf)_