### PR TITLE
Fix unhandled Brevo::ApiError in SyncBrevoNewslettersJob

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     brevo (4.0.0)
       addressable (~> 2.3, >= 2.3.0)
@@ -681,7 +681,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   brevo (4.0.0) sha256=016aff0108a8c90b55bbc414a30900f796c654ebc5d79c857d9b5fb37606fd05
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
     mustache (1.1.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -761,7 +761,7 @@ CHECKSUMS
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mustache (1.1.1) sha256=90891fdd50b53919ca334c8c1031eada1215e78d226d5795e523d6123a2717d0
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d

--- a/app/jobs/sync_brevo_newsletters_job.rb
+++ b/app/jobs/sync_brevo_newsletters_job.rb
@@ -38,7 +38,7 @@ class SyncBrevoNewslettersJob < ApplicationJob
     )
 
     Rails.logger.info("SyncBrevoNewslettersJob: Imported #{details.subject}")
-  rescue BrevoService::ApiError => e
+  rescue BrevoService::ApiError, Brevo::ApiError => e
     Rails.logger.warn("SyncBrevoNewslettersJob: Could not import campaign #{campaign_subject}: #{e.message}")
   end
 

--- a/test/jobs/sync_brevo_newsletters_job_test.rb
+++ b/test/jobs/sync_brevo_newsletters_job_test.rb
@@ -94,6 +94,26 @@ class SyncBrevoNewslettersJobTest < ActiveJob::TestCase
     assert_nil Newsletter.find_by(brevo_campaign_id: 101)
   end
 
+  test "continues past raw Brevo::ApiError from campaign_content" do
+    # Reproduces THENCF-H: if the service layer fails to wrap a Brevo::ApiError,
+    # the job must not crash and must continue processing remaining campaigns.
+    @stub_brevo.define_singleton_method(:campaign_content) do |id|
+      raise Brevo::ApiError.new(code: 404, message: "Not Found") if id == 101
+      OpenStruct.new(
+        subject: "November Newsletter",
+        html_content: "<html><body><p>Hello November</p></body></html>",
+        sent_date: "2024-11-01T09:00:00Z"
+      )
+    end
+
+    assert_difference "Newsletter.count", 1 do
+      SyncBrevoNewslettersJob.perform_now(brevo_service: @stub_brevo)
+    end
+
+    assert Newsletter.find_by(brevo_campaign_id: 102)
+    assert_nil Newsletter.find_by(brevo_campaign_id: 101)
+  end
+
   test "strips email HTML wrapper from content" do
     SyncBrevoNewslettersJob.perform_now(brevo_service: @stub_brevo)
 


### PR DESCRIPTION
## Root cause

`SyncBrevoNewslettersJob#import_campaign` only rescued `BrevoService::ApiError`. Normally `BrevoService#campaign_content` catches raw `Brevo::ApiError` and re-raises it wrapped as `BrevoService::ApiError` — but if the service layer ever fails to wrap it (gem change, code path gap, direct API call in a runner script), the raw `Brevo::ApiError` propagates all the way to Sentry as an unhandled exception.

This is what happened in production: [Sentry THENCF-H](https://seo-cahill.sentry.io/issues/THENCF-H) — `Brevo::ApiError: Not Found` from `get_email_campaign`, 4 occurrences on 2026-06-05, source `runner`.

## Fix

Added `Brevo::ApiError` to the rescue clause in `import_campaign` as a defensive fallback:

```ruby
rescue BrevoService::ApiError, Brevo::ApiError => e
```

The job already handles `BrevoService::ApiError` gracefully (logs a warning, continues with the next campaign). This change ensures the same behaviour for raw `Brevo::ApiError`, regardless of which layer the error surfaces from.

## Test plan

- [x] New failing test added: `continues past raw Brevo::ApiError from campaign_content` — confirmed fails before the fix, passes after
- [x] All existing Brevo tests pass (19 runs, 0 failures)
- [x] Full test suite unaffected by this change

---
_Generated by [Claude Code](https://claude.ai/code/session_01HytsRVY8zvPPi2VAAhAKAx)_