### PR TITLE
Fix SyncZohoEmailsJob failing on SSL/network errors (Sentry THENCF-V)

### DIFF
--- a/app/jobs/sync_zoho_emails_job.rb
+++ b/app/jobs/sync_zoho_emails_job.rb
@@ -15,8 +15,8 @@ class SyncZohoEmailsJob < ApplicationJob
 
     emails = @zoho.emails(folder_id: inbox_id, limit: SYNC_LIMIT)
     emails.each { |email_data| sync_email(inbox_id, email_data) }
-  rescue ZohoMailService::ApiError => e
-    Rails.logger.error("SyncZohoEmailsJob Zoho error: #{e.message}")
+  rescue ZohoMailService::ApiError, Faraday::Error => e
+    Rails.logger.error("SyncZohoEmailsJob network/API error: #{e.message}")
   end
 
   private

--- a/app/services/zoho_mail_service.rb
+++ b/app/services/zoho_mail_service.rb
@@ -162,6 +162,8 @@ class ZohoMailService
     end
 
     handle_response(response)
+  rescue Faraday::Error => e
+    raise ApiError, "Network error: #{e.message}"
   end
 
   def connection

--- a/test/jobs/sync_zoho_emails_job_test.rb
+++ b/test/jobs/sync_zoho_emails_job_test.rb
@@ -97,6 +97,14 @@ class SyncZohoEmailsJobTest < ActiveJob::TestCase
     end
   end
 
+  test "handles network connection failures gracefully" do
+    @stub_zoho.define_singleton_method(:folders) { raise Faraday::ConnectionFailed.new("Connection reset by peer - SSL_connect") }
+
+    assert_nothing_raised do
+      SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho)
+    end
+  end
+
   test "downloads and attaches email attachments" do
     attachment_info = [
       { "attachmentId" => "att_001", "attachmentName" => "poster.jpg", "attachmentSize" => 1234, "contentType" => "image/jpeg" },


### PR DESCRIPTION
## Root cause

`SyncZohoEmailsJob#perform` rescued `ZohoMailService::ApiError`, but `Faraday::ConnectionFailed` is a network-level exception raised before `ZohoMailService#handle_response` ever runs — so it was never wrapped in `ApiError` and escaped uncaught. This caused the job to be recorded as a failure in Sentry every time a transient SSL error hit the Zoho Mail API.

Sentry issue: https://seo-cahill.sentry.io/issues/THENCF-V

Stack trace key frame:
```
app/jobs/sync_zoho_emails_job.rb:25:in `find_inbox_folder_id`
app/services/zoho_mail_service.rb:160:in `get`
  → Faraday::ConnectionFailed: Connection reset by peer - SSL_connect
```

## Fix

Two-layer defence:

1. **`ZohoMailService#get`** — rescue `Faraday::Error` and re-raise as `ApiError`. This fulfils the service's error contract: callers only need to handle `ApiError`, not internal Faraday errors.

2. **`SyncZohoEmailsJob#perform`** — also rescue `Faraday::Error` as a fallback for any Faraday error that originates outside `#get` (e.g. `raw_connection` calls in `download_inline_image`/`download_attachment`).

## Test

Added `test "handles network connection failures gracefully"` to `SyncZohoEmailsJobTest` — confirms the job completes without raising when the Zoho service throws `Faraday::ConnectionFailed`.

---
_Generated by [Claude Code](https://claude.ai/code/session_01Gjw44Fwz9y7WHo8kPhBHZY)_