### PR TITLE
Fix SyncZohoEmailsJob crash on network failures (THENCF-V)

### DIFF
--- a/app/services/zoho_mail_service.rb
+++ b/app/services/zoho_mail_service.rb
@@ -162,6 +162,8 @@ class ZohoMailService
     end
 
     handle_response(response)
+  rescue Faraday::Error => e
+    raise ApiError, "Network error: #{e.message}"
   end
 
   def connection

--- a/test/services/zoho_mail_service_test.rb
+++ b/test/services/zoho_mail_service_test.rb
@@ -1,0 +1,22 @@
+require "test_helper"
+
+class ZohoMailServiceTest < ActiveSupport::TestCase
+  setup do
+    @service = ZohoMailService.new
+    @service.instance_variable_set(:@client_id, "test_client_id")
+    @service.instance_variable_set(:@client_secret, "test_client_secret")
+    @service.instance_variable_set(:@refresh_token, "test_refresh_token")
+    @service.instance_variable_set(:@account_id, "test_account_id")
+    @service.instance_variable_set(:@access_token, "test_token")
+    @service.instance_variable_set(:@region, :eu)
+  end
+
+  test "wraps Faraday::ConnectionFailed as ApiError" do
+    stub_request(:get, "https://mail.zoho.eu/api/accounts/test_account_id/folders")
+      .to_raise(Faraday::ConnectionFailed.new(RuntimeError.new("Connection reset by peer - SSL_connect")))
+
+    assert_raises(ZohoMailService::ApiError) do
+      @service.folders
+    end
+  end
+end


### PR DESCRIPTION
## Root cause

`ZohoMailService#get` wraps HTTP error responses (4xx/5xx) via `handle_response`, but did not rescue transport-level `Faraday::Error` exceptions (e.g. `Faraday::ConnectionFailed` from an SSL reset or TCP timeout). These propagated unhandled through `SyncZohoEmailsJob#perform`, which only rescues `ZohoMailService::ApiError`, causing the job to crash and report to Sentry.

Sentry issue: https://seo-cahill.sentry.io/issues/THENCF-V  
Stack trace confirms the crash at `zoho_mail_service.rb:160` → `Faraday::ConnectionFailed: Connection reset by peer - SSL_connect`.

## Fix

Added a `rescue Faraday::Error` in `ZohoMailService#get` that wraps any network failure as `ZohoMailService::ApiError`. This keeps the service's error contract clean — callers never need to handle transport exceptions.

```ruby
rescue Faraday::Error => e
  raise ApiError, "Network error: #{e.message}"
```

## Test

Added `test/services/zoho_mail_service_test.rb` with a test that stubs the Zoho folders endpoint to raise `Faraday::ConnectionFailed` via WebMock and asserts that `ZohoMailService::ApiError` is raised instead. Test fails without the fix, passes with it.

## Notes

- The other 4 Sentry issues (THENCF-H, THENCF-B, THENCF-S, THENCF-K) are all `source: runner` with no application frames — they came from ad-hoc `rails runner` scripts run on June 5-6, not from production app code, and are not reproducible from the current codebase.
- 7 pre-existing test failures exist in newsletter and bookings tests — unrelated to this change.

---
_Generated by [Claude Code](https://claude.ai/code/session_01AFGQHriwsf7jCwomUgB5iV)_