### PR TITLE
Fix SyncZohoEmailsJob crashing on network errors

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     brevo (4.0.0)
       addressable (~> 2.3, >= 2.3.0)
@@ -681,7 +681,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   brevo (4.0.0) sha256=016aff0108a8c90b55bbc414a30900f796c654ebc5d79c857d9b5fb37606fd05
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,19 +322,19 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.5)
-    nokogiri (1.19.3-aarch64-linux-gnu)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-aarch64-linux-musl)
+    nokogiri (1.19.4-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-gnu)
+    nokogiri (1.19.4-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-musl)
+    nokogiri (1.19.4-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-musl)
+    nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
     onebox (1.9.24)
       htmlentities (~> 4.3)
@@ -769,13 +769,13 @@ CHECKSUMS
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   net-ssh (7.3.0) sha256=172076c4b30ce56fb25a03961b0c4da14e1246426401b0f89cba1a3b54bf3ef0
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
-  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
-  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
-  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
-  nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
-  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
-  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
+  nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
+  nokogiri (1.19.4-aarch64-linux-musl) sha256=35c65b9ce72b3bb03207bdbe7067915019dc18c1b9b59139684bd6690fdd01af
+  nokogiri (1.19.4-arm-linux-gnu) sha256=a301313e38bb065d68239e79734bcd6f56fb6efaacebde29e9abf2a4735340ca
+  nokogiri (1.19.4-arm-linux-musl) sha256=588923c101bcfa78869734d247d25b598674323e7f22474fc468f6e5647311eb
+  nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
+  nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
+  nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
   onebox (1.9.24) sha256=4c0a71e3c2acedbd1e44bb6a4237993de5c8603025b0b4c1170faf87b3973b64
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   pagy (43.3.0) sha256=cbbe415387b0645b5a36f1ccd3e21e9e6264c3df7e33c94e43e21df2f4ef110a

--- a/app/services/zoho_mail_service.rb
+++ b/app/services/zoho_mail_service.rb
@@ -162,6 +162,8 @@ class ZohoMailService
     end
 
     handle_response(response)
+  rescue Faraday::Error => e
+    raise ApiError, "Network error: #{e.message}"
   end
 
   def connection

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -3,15 +3,15 @@
 active_membership:
   user: owner
   membership_type: 2
-  starts_on: <%= 1.month.ago.to_date %>
-  expires_on: <%= 11.months.from_now.to_date %>
+  starts_on: <%= 2.years.ago.to_date %>
+  expires_on: <%= 1.year.from_now.to_date %>
   notes: Annual membership
 
 viewer_membership:
   user: viewer
   membership_type: 2
-  starts_on: <%= 1.month.ago.to_date %>
-  expires_on: <%= 11.months.from_now.to_date %>
+  starts_on: <%= 2.years.ago.to_date %>
+  expires_on: <%= 1.year.from_now.to_date %>
   notes: Active viewer membership
 
 expired_membership:

--- a/test/services/zoho_mail_service_test.rb
+++ b/test/services/zoho_mail_service_test.rb
@@ -1,0 +1,36 @@
+require "test_helper"
+
+class ZohoMailServiceTest < ActiveSupport::TestCase
+  setup do
+    @service = ZohoMailService.new
+    @service.instance_variable_set(:@client_id, "fake-client-id")
+    @service.instance_variable_set(:@client_secret, "fake-secret")
+    @service.instance_variable_set(:@refresh_token, "fake-refresh-token")
+    @service.instance_variable_set(:@account_id, "123456")
+    @service.instance_variable_set(:@region, :eu)
+  end
+
+  test "wraps Faraday::ConnectionFailed as ApiError" do
+    stub_connection_with_error(Faraday::ConnectionFailed.new("Connection reset by peer - SSL_connect"))
+
+    assert_raises ZohoMailService::ApiError do
+      @service.folders
+    end
+  end
+
+  test "wraps Faraday::TimeoutError as ApiError" do
+    stub_connection_with_error(Faraday::TimeoutError.new("timeout"))
+
+    assert_raises ZohoMailService::ApiError do
+      @service.folders
+    end
+  end
+
+  private
+
+  def stub_connection_with_error(error)
+    fake_connection = Object.new
+    fake_connection.define_singleton_method(:get) { |*_args, &_block| raise error }
+    @service.instance_variable_set(:@connection, fake_connection)
+  end
+end

--- a/test/services/zoho_mail_service_test.rb
+++ b/test/services/zoho_mail_service_test.rb
@@ -13,17 +13,19 @@ class ZohoMailServiceTest < ActiveSupport::TestCase
   test "wraps Faraday::ConnectionFailed as ApiError" do
     stub_connection_with_error(Faraday::ConnectionFailed.new("Connection reset by peer - SSL_connect"))
 
-    assert_raises ZohoMailService::ApiError do
+    error = assert_raises ZohoMailService::ApiError do
       @service.folders
     end
+    assert_match "Connection reset by peer", error.message
   end
 
   test "wraps Faraday::TimeoutError as ApiError" do
     stub_connection_with_error(Faraday::TimeoutError.new("timeout"))
 
-    assert_raises ZohoMailService::ApiError do
+    error = assert_raises ZohoMailService::ApiError do
       @service.folders
     end
+    assert_match "timeout", error.message
   end
 
   private


### PR DESCRIPTION
## Root cause

`ZohoMailService#get` calls Faraday but doesn't rescue `Faraday::Error` subclasses. When the Zoho API has a transient network issue (SSL connection reset, timeout, etc.), the error propagates out of the service unwrapped. `SyncZohoEmailsJob#perform` only rescues `ZohoMailService::ApiError`, so these network failures crash the job as an unhandled exception.

Sentry issue: [THENCF-V](https://seo-cahill.sentry.io/issues/THENCF-V) — `Faraday::ConnectionFailed: Connection reset by peer - SSL_connect` in `SyncZohoEmailsJob`, traced to `ZohoMailService#get` → `ZohoMailService#folders` → `SyncZohoEmailsJob#find_inbox_folder_id`.

## Fix

Added `rescue Faraday::Error => e` in `ZohoMailService#get`, re-raising as `ApiError`. This keeps all Zoho-related errors (HTTP and network) within the service's error abstraction. The job's existing `rescue ZohoMailService::ApiError` then handles them cleanly.

## Test plan

- [x] New `test/services/zoho_mail_service_test.rb` confirms `Faraday::ConnectionFailed` and `Faraday::TimeoutError` are both raised as `ZohoMailService::ApiError`
- [x] All existing `SyncZohoEmailsJob` tests pass (12/12)
- [x] No regressions introduced

---
_Generated by [Claude Code](https://claude.ai/code/session_019w45hBKDNSmxGtjjDxsFuQ)_