### PR TITLE
Wrap Faraday network errors as ZohoMailService::ApiError

### DIFF
--- a/app/services/zoho_mail_service.rb
+++ b/app/services/zoho_mail_service.rb
@@ -162,6 +162,8 @@ class ZohoMailService
     end
 
     handle_response(response)
+  rescue Faraday::Error => e
+    raise ApiError, "Network error: #{e.message}"
   end
 
   def connection

--- a/test/services/zoho_mail_service_test.rb
+++ b/test/services/zoho_mail_service_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class ZohoMailServiceTest < ActiveSupport::TestCase
+  setup do
+    @service = ZohoMailService.new
+
+    # Inject a pre-built connection so we skip OAuth token fetching
+    fake_connection = Object.new
+    @service.instance_variable_set(:@connection, fake_connection)
+    @fake_connection = fake_connection
+  end
+
+  test "wraps Faraday::ConnectionFailed as ApiError" do
+    @fake_connection.define_singleton_method(:get) do |_path, &_block|
+      raise Faraday::ConnectionFailed, "Connection reset by peer - SSL_connect"
+    end
+
+    assert_raises(ZohoMailService::ApiError) do
+      @service.folders
+    end
+  end
+
+  test "wraps Faraday::TimeoutError as ApiError" do
+    @fake_connection.define_singleton_method(:get) do |_path, &_block|
+      raise Faraday::TimeoutError
+    end
+
+    assert_raises(ZohoMailService::ApiError) do
+      @service.folders
+    end
+  end
+end


### PR DESCRIPTION
## Root cause

`SyncZohoEmailsJob` rescues `ZohoMailService::ApiError` to handle transient API failures gracefully. But `Faraday::ConnectionFailed` and `Faraday::TimeoutError` — network-level errors raised by the Faraday gem directly — were not wrapped by the service layer. They escaped the job's rescue block and caused unhandled job failures recorded in Sentry.

Sentry issue: https://seo-cahill.sentry.io/issues/THENCF-V

The failing event was `SyncZohoEmailsJob` → `ZohoMailService#folders` → `Faraday::ConnectionFailed: Connection reset by peer - SSL_connect` (a transient SSL network error at 06:00 UTC on 2026-06-19).

## Fix

Added `rescue Faraday::Error` in `ZohoMailService#get` to catch all Faraday network exceptions (`ConnectionFailed`, `TimeoutError`, etc.) and re-raise them as `ZohoMailService::ApiError`. The job's existing rescue block then logs and exits cleanly rather than the job failing.

## Test plan

- [x] New `test/services/zoho_mail_service_test.rb` with two tests confirming `Faraday::ConnectionFailed` and `Faraday::TimeoutError` are wrapped as `ApiError`
- [x] Tests confirmed failing before fix, passing after
- [x] All existing `SyncZohoEmailsJob` tests continue to pass
- [x] Full test suite: no regressions introduced (pre-existing failures in `BookingsControllerTest`, `GenerateNewsletterContentJobTest`, `NewsletterContentServiceTest` unrelated to this change)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017nsQuqYDRtDCRWv1TAj2vG

---
_Generated by [Claude Code](https://claude.ai/code/session_017nsQuqYDRtDCRWv1TAj2vG)_