### PR TITLE
Fix ZohoMailService swallowing network errors in SyncZohoEmailsJob

### DIFF
--- a/app/services/zoho_mail_service.rb
+++ b/app/services/zoho_mail_service.rb
@@ -162,6 +162,8 @@ class ZohoMailService
     end
 
     handle_response(response)
+  rescue Faraday::Error => e
+    raise ApiError, "Connection error: #{e.message}"
   end
 
   def connection

--- a/test/services/zoho_mail_service_test.rb
+++ b/test/services/zoho_mail_service_test.rb
@@ -1,0 +1,32 @@
+require "test_helper"
+
+class ZohoMailServiceTest < ActiveSupport::TestCase
+  setup do
+    @service = ZohoMailService.new
+    @service.instance_variable_set(:@region, :eu)
+    @service.instance_variable_set(:@client_id, "test_client_id")
+    @service.instance_variable_set(:@client_secret, "test_secret")
+    @service.instance_variable_set(:@refresh_token, "test_refresh")
+    @service.instance_variable_set(:@account_id, "123456789")
+    # Skip OAuth by injecting a token directly
+    @service.instance_variable_set(:@access_token, "test_access_token")
+  end
+
+  test "folders wraps Faraday::ConnectionFailed as ApiError" do
+    stub_request(:get, "https://mail.zoho.eu/api/accounts/123456789/folders")
+      .to_raise(Errno::ECONNRESET)
+
+    assert_raises(ZohoMailService::ApiError) do
+      @service.folders
+    end
+  end
+
+  test "folders wraps Faraday::TimeoutError as ApiError" do
+    stub_request(:get, "https://mail.zoho.eu/api/accounts/123456789/folders")
+      .to_raise(Faraday::TimeoutError)
+
+    assert_raises(ZohoMailService::ApiError) do
+      @service.folders
+    end
+  end
+end


### PR DESCRIPTION
## Root cause

`ZohoMailService#get` makes Faraday HTTP requests but only `handle_response` raised `ZohoMailService::ApiError` — for HTTP-level errors (4xx, 5xx). Network-level failures (SSL reset, timeout, connection refused) raise `Faraday::Error` subclasses directly, which are **not** caught by `ZohoMailService::ApiError`.

`SyncZohoEmailsJob#perform` rescues only `ZohoMailService::ApiError`, so when the Zoho API connection reset the SSL handshake (as it did on 2026-06-19), `Faraday::ConnectionFailed` propagated all the way up as an unhandled exception.

## Fix

Added `rescue Faraday::Error => e` to `ZohoMailService#get`, wrapping it as `ApiError` before it reaches callers. This is the correct service boundary: callers shouldn't need to know the underlying HTTP client.

## Test

Added `test/services/zoho_mail_service_test.rb` verifying that `Faraday::ConnectionFailed` (simulated via `Errno::ECONNRESET` with WebMock) and `Faraday::TimeoutError` are both raised as `ZohoMailService::ApiError` from `#folders`. Both tests failed before the fix, pass after.

## Sentry issue

https://seo-cahill.sentry.io/issues/THENCF-V

---
_Generated by [Claude Code](https://claude.ai/code/session_01Rm7n1E8ocByMJSRBT2BZve)_