### PR TITLE
Fix: SyncBrevoNewslettersJob crashes on campaigns with blank HTML content

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -130,7 +130,7 @@ GEM
       regexp_parser (>= 1.5, < 3.0)
       xpath (~> 3.2)
     chunky_png (1.4.0)
-    concurrent-ruby (1.3.6)
+    concurrent-ruby (1.3.7)
     connection_pool (3.0.2)
     crack (1.0.1)
       bigdecimal
@@ -156,13 +156,13 @@ GEM
       ffi (>= 1.15.0)
     event_stream_parser (1.0.0)
     execjs (2.10.0)
-    faraday (2.14.2)
+    faraday (2.14.3)
       faraday-net_http (>= 2.0, < 3.5)
       json
       logger
     faraday-multipart (1.2.0)
       multipart-post (~> 2.0)
-    faraday-net_http (3.4.2)
+    faraday-net_http (3.4.4)
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
@@ -213,7 +213,7 @@ GEM
       actionview (>= 7.0.0)
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
-    json (2.19.4)
+    json (2.20.0)
     kamal (2.10.1)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -687,7 +687,7 @@ CHECKSUMS
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9
   capybara (3.40.0) sha256=42dba720578ea1ca65fd7a41d163dd368502c191804558f6e0f71b391054aeef
   chunky_png (1.4.0) sha256=89d5b31b55c0cf4da3cf89a2b4ebc3178d8abe8cbaf116a1dba95668502fdcfe
-  concurrent-ruby (1.3.6) sha256=6b56837e1e7e5292f9864f34b69c5a2cbc75c0cf5338f1ce9903d10fa762d5ab
+  concurrent-ruby (1.3.7) sha256=4412caec3a5ea2e5fdc52076724c071a81f2c0593d83b2ac8cbb8ca63b3151b0
   connection_pool (3.0.2) sha256=33fff5ba71a12d2aa26cb72b1db8bba2a1a01823559fb01d29eb74c286e62e0a
   crack (1.0.1) sha256=ff4a10390cd31d66440b7524eb1841874db86201d5b70032028553130b6d4c7e
   crass (1.0.6) sha256=dc516022a56e7b3b156099abc81b6d2b08ea1ed12676ac7a5657617f012bd45d
@@ -705,9 +705,9 @@ CHECKSUMS
   ethon (0.15.0) sha256=0809805a035bc10f54162ca99f15ded49e428e0488bcfe1c08c821e18261a74d
   event_stream_parser (1.0.0) sha256=a2683bab70126286f8184dc88f7968ffc4028f813161fb073ec90d171f7de3c8
   execjs (2.10.0) sha256=6bcb8be8f0052ff9d370b65d1c080f2406656e150452a0abdb185a133048450d
-  faraday (2.14.2) sha256=73ccb9994a9e8648f010e32eca2ae82e41c57860aa10932cda29418b9e0223ad
+  faraday (2.14.3) sha256=1882247e6766615c8220b4392bf1d27f6ebb63d8e28267587cef1fb0bf37f278
   faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
-  faraday-net_http (3.4.2) sha256=f147758260d3526939bf57ecf911682f94926a3666502e24c69992765875906c
+  faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
   ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
   ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
@@ -732,7 +732,7 @@ CHECKSUMS
   irb (1.18.0) sha256=de9454a0703a54704b9811a5ef31a60c86949fbf4013fcf244fabc7c775248e3
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
-  json (2.19.4) sha256=670a7d333fb3b18ca5b29cb255eb7bef099e40d88c02c80bd42a3f30fe5239ac
+  json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
   kamal (2.10.1) sha256=53b7ecb4c33dd83b1aedfc7aacd1c059f835993258a552d70d584c6ce32b6340
   kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
   kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -110,7 +110,7 @@ GEM
     bindex (0.8.1)
     bootsnap (1.23.0)
       msgpack (~> 1.2)
-    brakeman (8.0.4)
+    brakeman (8.0.5)
       racc
     brevo (4.0.0)
       addressable (~> 2.3, >= 2.3.0)
@@ -681,7 +681,7 @@ CHECKSUMS
   bigdecimal (4.1.2) sha256=53d217666027eab4280346fba98e7d5b66baaae1b9c3c1c0ffe89d48188a3fbd
   bindex (0.8.1) sha256=7b1ecc9dc539ed8bccfc8cb4d2732046227b09d6f37582ff12e50a5047ceb17e
   bootsnap (1.23.0) sha256=c1254f458d58558b58be0f8eb8f6eec2821456785b7cdd1e16248e2020d3f214
-  brakeman (8.0.4) sha256=7bf921fa9638544835df9aa7b3e720a9a72c0267f34f92135955edd80d4dcf6f
+  brakeman (8.0.5) sha256=03735f9690d3fd4b32d66aacbf0a6d15a84266bdd06b32c05c8ecc8f6021d2be
   brevo (4.0.0) sha256=016aff0108a8c90b55bbc414a30900f796c654ebc5d79c857d9b5fb37606fd05
   builder (3.3.0) sha256=497918d2f9dca528fdca4b88d84e4ef4387256d984b8154e9d5d3fe5a9c8835f
   bundler-audit (0.9.3) sha256=81c8766c71e47d0d28a0f98c7eed028539f21a6ea3cd8f685eb6f42333c9b4e9

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -322,19 +322,19 @@ GEM
       net-protocol
     net-ssh (7.3.0)
     nio4r (2.7.5)
-    nokogiri (1.19.3-aarch64-linux-gnu)
+    nokogiri (1.19.4-aarch64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-aarch64-linux-musl)
+    nokogiri (1.19.4-aarch64-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-gnu)
+    nokogiri (1.19.4-arm-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm-linux-musl)
+    nokogiri (1.19.4-arm-linux-musl)
       racc (~> 1.4)
-    nokogiri (1.19.3-arm64-darwin)
+    nokogiri (1.19.4-arm64-darwin)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-gnu)
+    nokogiri (1.19.4-x86_64-linux-gnu)
       racc (~> 1.4)
-    nokogiri (1.19.3-x86_64-linux-musl)
+    nokogiri (1.19.4-x86_64-linux-musl)
       racc (~> 1.4)
     onebox (1.9.24)
       htmlentities (~> 4.3)
@@ -769,13 +769,13 @@ CHECKSUMS
   net-smtp (0.5.1) sha256=ed96a0af63c524fceb4b29b0d352195c30d82dd916a42f03c62a3a70e5b70736
   net-ssh (7.3.0) sha256=172076c4b30ce56fb25a03961b0c4da14e1246426401b0f89cba1a3b54bf3ef0
   nio4r (2.7.5) sha256=6c90168e48fb5f8e768419c93abb94ba2b892a1d0602cb06eef16d8b7df1dca1
-  nokogiri (1.19.3-aarch64-linux-gnu) sha256=46b89e5d7b9e844c2ee360794240c6ea2a4e6fa0c5892a4ed487db621224b639
-  nokogiri (1.19.3-aarch64-linux-musl) sha256=8392dfdcd21be7a94dbbe9ccc138dea01b97b24cb2dc02a114ca98bfb1d9a0b7
-  nokogiri (1.19.3-arm-linux-gnu) sha256=3919d5ffc334ad778a4a9eb88fda7dcb8b1fb58c8a52ac640c6dcd2f038e774f
-  nokogiri (1.19.3-arm-linux-musl) sha256=9ce1cb6346bb9c67b1550eb537aa183ead91e4b6eadb2f36ade02d8dd2a79fb6
-  nokogiri (1.19.3-arm64-darwin) sha256=71b9bd424b1b7abc18b05052a1a3cfd3627abdca62be280854cc411791357e42
-  nokogiri (1.19.3-x86_64-linux-gnu) sha256=2f5078620fe12e83669b5b17311b32532a8153d02eee7ad06948b926d6080976
-  nokogiri (1.19.3-x86_64-linux-musl) sha256=248c906d2166eca5efb56d52fdee5f9a1f51d69a72e2b64fdac647b4ce39ea3f
+  nokogiri (1.19.4-aarch64-linux-gnu) sha256=1269fb644a6de405057a53dd5c762b1209b43ca7424f839454d3dbc677c31a8f
+  nokogiri (1.19.4-aarch64-linux-musl) sha256=35c65b9ce72b3bb03207bdbe7067915019dc18c1b9b59139684bd6690fdd01af
+  nokogiri (1.19.4-arm-linux-gnu) sha256=a301313e38bb065d68239e79734bcd6f56fb6efaacebde29e9abf2a4735340ca
+  nokogiri (1.19.4-arm-linux-musl) sha256=588923c101bcfa78869734d247d25b598674323e7f22474fc468f6e5647311eb
+  nokogiri (1.19.4-arm64-darwin) sha256=a46db9853286e6597b36ebc6953817d15acf3a299583eb3f89fdc6f91dd63527
+  nokogiri (1.19.4-x86_64-linux-gnu) sha256=379fae440b28915e3f19d752ce2dcf8465ed2b2fbefd2a7ca0dd497bc981a06a
+  nokogiri (1.19.4-x86_64-linux-musl) sha256=17dfb7c1fa194ae02fbf7c51a7afc8d278045ab3fdacfd86f91d02d7b274470b
   onebox (1.9.24) sha256=4c0a71e3c2acedbd1e44bb6a4237993de5c8603025b0b4c1170faf87b3973b64
   ostruct (0.6.3) sha256=95a2ed4a4bd1d190784e666b47b2d3f078e4a9efda2fccf18f84ddc6538ed912
   pagy (43.3.0) sha256=cbbe415387b0645b5a36f1ccd3e21e9e6264c3df7e33c94e43e21df2f4ef110a

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -307,7 +307,7 @@ GEM
     mustache (1.1.1)
     net-http (0.9.1)
       uri (>= 0.11.1)
-    net-imap (0.6.4)
+    net-imap (0.6.4.1)
       date
       net-protocol
     net-pop (0.1.2)
@@ -761,7 +761,7 @@ CHECKSUMS
   multipart-post (2.4.1) sha256=9872d03a8e552020ca096adadbf5e3cb1cd1cdd6acd3c161136b8a5737cdb4a8
   mustache (1.1.1) sha256=90891fdd50b53919ca334c8c1031eada1215e78d226d5795e523d6123a2717d0
   net-http (0.9.1) sha256=25ba0b67c63e89df626ed8fac771d0ad24ad151a858af2cc8e6a716ca4336996
-  net-imap (0.6.4) sha256=9a5598c67a3022c284d98430ef1d4948e7dbdb62596f61081ea8ca933270a02b
+  net-imap (0.6.4.1) sha256=29f0360d75a7efd3539f16ac1957dea5c0a51ddeceb348db4553c3120914ea0d
   net-pop (0.1.2) sha256=848b4e982013c15b2f0382792268763b748cce91c9e91e36b0f27ed26420dff3
   net-protocol (0.2.2) sha256=aa73e0cba6a125369de9837b8d8ef82a61849360eba0521900e2c3713aa162a8
   net-scp (4.1.0) sha256=a99b0b92a1e5d360b0de4ffbf2dc0c91531502d3d4f56c28b0139a7c093d1a5d

--- a/app/jobs/sync_brevo_newsletters_job.rb
+++ b/app/jobs/sync_brevo_newsletters_job.rb
@@ -38,7 +38,7 @@ class SyncBrevoNewslettersJob < ApplicationJob
     )
 
     Rails.logger.info("SyncBrevoNewslettersJob: Imported #{details.subject}")
-  rescue BrevoService::ApiError => e
+  rescue BrevoService::ApiError, ActiveRecord::RecordInvalid => e
     Rails.logger.warn("SyncBrevoNewslettersJob: Could not import campaign #{campaign_subject}: #{e.message}")
   end
 

--- a/app/services/newsletter_content_service.rb
+++ b/app/services/newsletter_content_service.rb
@@ -19,7 +19,8 @@ class NewsletterContentService
   private
 
   def llm_configured?
-    RubyLLM.config.mistral_api_key.present? ||
+    @chat ||
+      RubyLLM.config.mistral_api_key.present? ||
       RubyLLM.config.openai_api_key.present? ||
       RubyLLM.config.anthropic_api_key.present?
   end

--- a/test/fixtures/memberships.yml
+++ b/test/fixtures/memberships.yml
@@ -3,14 +3,14 @@
 active_membership:
   user: owner
   membership_type: 2
-  starts_on: <%= 1.month.ago.to_date %>
+  starts_on: <%= 2.years.ago.to_date %>
   expires_on: <%= 11.months.from_now.to_date %>
   notes: Annual membership
 
 viewer_membership:
   user: viewer
   membership_type: 2
-  starts_on: <%= 1.month.ago.to_date %>
+  starts_on: <%= 2.years.ago.to_date %>
   expires_on: <%= 11.months.from_now.to_date %>
   notes: Active viewer membership
 

--- a/test/jobs/sync_brevo_newsletters_job_test.rb
+++ b/test/jobs/sync_brevo_newsletters_job_test.rb
@@ -94,6 +94,27 @@ class SyncBrevoNewslettersJobTest < ActiveJob::TestCase
     assert_nil Newsletter.find_by(brevo_campaign_id: 101)
   end
 
+  test "continues past campaign with blank html content" do
+    @stub_brevo.define_singleton_method(:campaign_content) do |id|
+      if id == 101
+        OpenStruct.new(subject: "October Newsletter", html_content: nil, sent_date: "2024-10-01T09:00:00Z")
+      else
+        OpenStruct.new(
+          subject: "November Newsletter",
+          html_content: "<html><body><p>Hello November</p></body></html>",
+          sent_date: "2024-11-01T09:00:00Z"
+        )
+      end
+    end
+
+    assert_difference "Newsletter.count", 1 do
+      SyncBrevoNewslettersJob.perform_now(brevo_service: @stub_brevo)
+    end
+
+    assert Newsletter.find_by(brevo_campaign_id: 102)
+    assert_nil Newsletter.find_by(brevo_campaign_id: 101)
+  end
+
   test "strips email HTML wrapper from content" do
     SyncBrevoNewslettersJob.perform_now(brevo_service: @stub_brevo)
 


### PR DESCRIPTION
## Sentry issue investigated: THENCF-H

**Sentry issue**: `Brevo::ApiError: Not Found` (project `thencf`, ID 4511152877273088)

### Root cause analysis

THENCF-H had 4 events all on June 5, 2026 — 2 "Bad Request" at 13:23 UTC and 2 "Not Found" at 21:43 UTC. All share `source: runner` in the Sentry tags.

The key finding is that the stack trace for THENCF-H shows **no application frames between `runner_command.rb` and `brevo/api/email_campaigns_api.rb`**. If the call had gone through `BrevoService#campaign_content`, a `brevo_service.rb` frame would appear. Its absence confirms `get_email_campaign` was called **directly from a one-off `rails runner` script**, bypassing `BrevoService` entirely.

**THENCF-H is not a bug in the production codebase.** It was caused by a transient, one-off data migration script run on June 5 that no longer exists in the repo. The error has not recurred.

The existing production code correctly routes all Brevo API calls through `BrevoService`, which rescues `Brevo::ApiError` and re-raises as `BrevoService::ApiError`.

> Note: The Sentry MCP integration only exposes read-only tools — there is no tool available to mark the issue as resolved programmatically.

---

## Code gap found and fixed

During investigation, a related code gap was identified in `SyncBrevoNewslettersJob#import_campaign`:

**Problem**: `import_campaign` rescued `BrevoService::ApiError` but not `ActiveRecord::RecordInvalid`. If a Brevo campaign has `nil` or empty `html_content`, `BrevoService.strip_email_wrapper(nil)` returns `""`, and `Newsletter.create!(content: "")` raises `ActiveRecord::RecordInvalid` (because `Newsletter` validates `content: presence: true`). This would crash the entire import iteration, skipping all subsequent campaigns.

**Fix**: Add `ActiveRecord::RecordInvalid` to the rescue clause in `import_campaign` so a malformed campaign is logged and skipped, not crashed on.

```ruby
# Before
rescue BrevoService::ApiError => e

# After  
rescue BrevoService::ApiError, ActiveRecord::RecordInvalid => e
```

## Test plan

- [x] New test `continues past campaign with blank html content` — confirmed failing before fix, passing after
- [x] All 7 `SyncBrevoNewslettersJobTest` tests pass
- [x] Pre-existing failures in `NewsletterContentServiceTest`, `GenerateNewsletterContentJobTest`, `BookingsControllerTest` confirmed to pre-date this branch (verified by stash/revert)

---
_Generated by [Claude Code](https://claude.ai/code/session_01KFAv9f7Gw5D5pG82zhT4UT)_