### PR TITLE
Admin MCP server: expose todo, email, event, funding, newsletter and booking tools

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,9 @@ gem "brevo"
 # Forum engine [https://github.com/thredded/thredded]
 gem "thredded"
 
+# Model Context Protocol server, exposes admin tools to AI clients [https://github.com/yjacquin/fast-mcp]
+gem "fast-mcp", require: "fast_mcp"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -148,6 +148,35 @@ GEM
       rails (>= 3.0.0)
     dotenv (3.2.0)
     drb (2.2.3)
+    dry-configurable (1.4.0)
+      dry-core (~> 1.0)
+      zeitwerk (~> 2.6)
+    dry-core (1.2.0)
+      concurrent-ruby (~> 1.0)
+      logger
+      zeitwerk (~> 2.6)
+    dry-inflector (1.3.1)
+    dry-initializer (3.2.0)
+    dry-logic (1.6.0)
+      bigdecimal
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.1)
+      zeitwerk (~> 2.6)
+    dry-schema (1.16.0)
+      concurrent-ruby (~> 1.0)
+      dry-configurable (~> 1.0, >= 1.0.1)
+      dry-core (~> 1.1)
+      dry-initializer (~> 3.2)
+      dry-logic (~> 1.6)
+      dry-types (~> 1.9, >= 1.9.1)
+      zeitwerk (~> 2.6)
+    dry-types (1.9.1)
+      bigdecimal (>= 3.0)
+      concurrent-ruby (~> 1.0)
+      dry-core (~> 1.0)
+      dry-inflector (~> 1.0)
+      dry-logic (~> 1.4)
+      zeitwerk (~> 2.6)
     ed25519 (1.4.0)
     erb (6.0.4)
     erubi (1.13.1)
@@ -167,6 +196,13 @@ GEM
       net-http (~> 0.5)
     faraday-retry (2.4.0)
       faraday (~> 2.0)
+    fast-mcp (1.6.0)
+      addressable (~> 2.8)
+      base64
+      dry-schema (~> 1.14)
+      json (~> 2.0)
+      mime-types (~> 3.4)
+      rack (>= 2.0, < 4.0)
     ffi (1.17.3-aarch64-linux-gnu)
     ffi (1.17.3-aarch64-linux-musl)
     ffi (1.17.3-arm-linux-gnu)
@@ -286,6 +322,10 @@ GEM
       net-smtp
     marcel (1.1.0)
     matrix (0.4.3)
+    mime-types (3.7.0)
+      logger
+      mime-types-data (~> 3.2025, >= 3.2025.0507)
+    mime-types-data (3.2026.0414)
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
@@ -619,6 +659,7 @@ DEPENDENCIES
   dockerfile-rails (>= 1.7)
   dotenv (~> 3.2)
   faraday
+  fast-mcp
   icalendar
   image_processing (~> 1.2)
   importmap-rails
@@ -700,6 +741,13 @@ CHECKSUMS
   dockerfile-rails (1.7.10) sha256=04163273792ec6c6560244d32c0b44bbed705384a47b8063adcbf0d7bc8abd26
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
+  dry-configurable (1.4.0) sha256=e35d1b5f3c081753ef361f564919db79000f32cfa6f20ee3a3ba5921b41b73ce
+  dry-core (1.2.0) sha256=0cc5a7da88df397f153947eeeae42e876e999c1e30900f3c536fb173854e96a1
+  dry-inflector (1.3.1) sha256=7fb0c2bb04f67638f25c52e7ba39ab435d922a3a5c3cd196120f63accb682dcc
+  dry-initializer (3.2.0) sha256=37d59798f912dc0a1efe14a4db4a9306989007b302dcd5f25d0a2a20c166c4e3
+  dry-logic (1.6.0) sha256=da6fedbc0f90fc41f9b0cc7e6f05f5d529d1efaef6c8dcc8e0733f685745cea2
+  dry-schema (1.16.0) sha256=cd3aaeabc0f1af66ec82a29096d4c4fb92a0a58b9dae29a22b1bbceb78985727
+  dry-types (1.9.1) sha256=baebeecdb9f8395d6c9d227b62011279440943e3ef2468fe8ccc1ba11467f178
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
   erb (6.0.4) sha256=38e3803694be357fe2bfe312487c74beaf9fb4e5beb3e22498952fe1645b95d9
   erubi (1.13.1) sha256=a082103b0885dbc5ecf1172fede897f9ebdb745a4b97a5e8dc63953db1ee4ad9
@@ -711,6 +759,7 @@ CHECKSUMS
   faraday-multipart (1.2.0) sha256=7d89a949693714176f612323ca13746a2ded204031a6ba528adee788694ef757
   faraday-net_http (3.4.4) sha256=0e78af151747ed1b00f33e25973b4bc220d7f16c00c39676817c8b12331eb588
   faraday-retry (2.4.0) sha256=7b79c48fb7e56526faf247b12d94a680071ff40c9fda7cf1ec1549439ad11ebe
+  fast-mcp (1.6.0) sha256=d68abb45d2daab9e7ae2934417460e4bf9ac87493c585dc5bb626f1afb7d12c4
   ffi (1.17.3-aarch64-linux-gnu) sha256=28ad573df26560f0aedd8a90c3371279a0b2bd0b4e834b16a2baa10bd7a97068
   ffi (1.17.3-aarch64-linux-musl) sha256=020b33b76775b1abacc3b7d86b287cef3251f66d747092deec592c7f5df764b2
   ffi (1.17.3-arm-linux-gnu) sha256=5bd4cea83b68b5ec0037f99c57d5ce2dd5aa438f35decc5ef68a7d085c785668
@@ -754,6 +803,8 @@ CHECKSUMS
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
+  mime-types (3.7.0) sha256=dcebf61c246f08e15a4de34e386ebe8233791e868564a470c3fe77c00eed5e56
+  mime-types-data (3.2026.0414) sha256=461c4c655373a44bd6c5fe54bcf5b7776026ea96e808144b1ec465c4b99148cc
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1

--- a/app/models/cached_email.rb
+++ b/app/models/cached_email.rb
@@ -14,6 +14,13 @@ class CachedEmail < ApplicationRecord
   scope :without_admin_todo, -> {
     where.not(id: AdminTodo.where(source_type: name).select(:source_id))
   }
+  scope :search, ->(term) {
+    next all if term.blank?
+
+    pattern = "%#{sanitize_sql_like(term)}%"
+    where("LOWER(subject) LIKE LOWER(?) OR LOWER(from_address) LIKE LOWER(?) OR LOWER(summary) LIKE LOWER(?)",
+          pattern, pattern, pattern)
+  }
 
   # Automated sender prefixes that almost never warrant a follow-up todo
   # (security mailers, transactional notifiers, shipping bots, etc.).

--- a/app/models/funding_opportunity.rb
+++ b/app/models/funding_opportunity.rb
@@ -18,6 +18,13 @@ class FundingOpportunity < ApplicationRecord
   scope :upcoming, -> { approved.open.order(:deadline) }
   scope :approved_or_owned_by, ->(user) { where(approved: true).or(where(created_by: user)) }
   scope :by_category, ->(category) { where("categories LIKE ?", "%#{category}%") }
+  scope :search, ->(term) {
+    next all if term.blank?
+
+    pattern = "%#{sanitize_sql_like(term)}%"
+    where("LOWER(title) LIKE LOWER(?) OR LOWER(organization) LIKE LOWER(?) OR LOWER(description) LIKE LOWER(?)",
+          pattern, pattern, pattern)
+  }
 
   def closed?
     deadline < Date.current

--- a/app/tools/application_tool.rb
+++ b/app/tools/application_tool.rb
@@ -2,4 +2,11 @@
 # alias that fast-mcp installs (== FastMcp::Tool). Tools placed in app/tools are
 # auto-registered with the MCP server mounted in config/initializers/fast_mcp.rb.
 class ApplicationTool < ActionTool::Base
+  private
+
+  # Records created over MCP have no session user, so they are attributed to the
+  # owner account. Tools that need an owner should fail clearly when none exists.
+  def owner_user
+    User.owner.order(:id).first
+  end
 end

--- a/app/tools/application_tool.rb
+++ b/app/tools/application_tool.rb
@@ -1,0 +1,5 @@
+# Base class for all MCP tools. Inherits the Rails-friendly ActionTool::Base
+# alias that fast-mcp installs (== FastMcp::Tool). Tools placed in app/tools are
+# auto-registered with the MCP server mounted in config/initializers/fast_mcp.rb.
+class ApplicationTool < ActionTool::Base
+end

--- a/app/tools/archive_email_tool.rb
+++ b/app/tools/archive_email_tool.rb
@@ -1,0 +1,16 @@
+class ArchiveEmailTool < ApplicationTool
+  tool_name "archive_email"
+  description "Archive a cached inbox email by its id."
+
+  arguments do
+    required(:id).filled(:integer).description("The id of the email to archive")
+  end
+
+  def call(id:)
+    email = CachedEmail.find_by(id: id)
+    return "No email found with id #{id}." if email.nil?
+
+    email.archived!
+    "Archived email ##{id}: #{email.subject}"
+  end
+end

--- a/app/tools/create_event_tool.rb
+++ b/app/tools/create_event_tool.rb
@@ -1,0 +1,62 @@
+class CreateEventTool < ApplicationTool
+  tool_name "create_event"
+  description <<~DESC.squish
+    Create a draft (unpublished) event owned by the owner account. Optionally
+    pass from_email_id to copy the first image attachment of that email into the
+    event image. An editor still has to publish the event.
+  DESC
+
+  arguments do
+    required(:title).filled(:string)
+    required(:starts_at).filled(:string).description("Start time, e.g. 2026-05-01 19:30")
+    optional(:ends_at).filled(:string).description("End time")
+    optional(:description).filled(:string)
+    optional(:venue_name).filled(:string)
+    optional(:venue_address).filled(:string)
+    optional(:from_email_id).filled(:integer).description("Cached email to source an image from")
+  end
+
+  def call(title:, starts_at:, ends_at: nil, description: nil, venue_name: nil, venue_address: nil, from_email_id: nil)
+    owner = owner_user
+    return "No owner account configured; cannot create events." if owner.nil?
+
+    parsed_start = parse_time(starts_at)
+    return "Invalid start time #{starts_at.inspect}." if parsed_start.nil?
+
+    if ends_at.present? && (parsed_end = parse_time(ends_at)).nil?
+      return "Invalid end time #{ends_at.inspect}."
+    end
+
+    event = owner.events.build(
+      title: title, starts_at: parsed_start, ends_at: parsed_end,
+      description: description, venue_name: venue_name, venue_address: venue_address
+    )
+    event.save!
+
+    image_note = attach_image_from_email(event, from_email_id)
+    "Created draft event ##{event.id}: #{event.title}.#{image_note}"
+  rescue ActiveRecord::RecordInvalid => e
+    "Could not create event: #{e.record.errors.full_messages.join(', ')}"
+  end
+
+  private
+
+  def attach_image_from_email(event, from_email_id)
+    return "" if from_email_id.blank?
+
+    email = CachedEmail.find_by(id: from_email_id)
+    return " (email #{from_email_id} not found)" if email.nil?
+
+    image = email.attachments.find { |att| att.content_type.to_s.start_with?("image/") }
+    return " (no image attachment on email #{from_email_id})" if image.nil?
+
+    event.image.attach(io: StringIO.new(image.download), filename: image.filename.to_s, content_type: image.content_type)
+    " Attached image #{image.filename}."
+  end
+
+  def parse_time(value)
+    Time.zone.parse(value.to_s)
+  rescue ArgumentError
+    nil
+  end
+end

--- a/app/tools/create_funding_opportunity_tool.rb
+++ b/app/tools/create_funding_opportunity_tool.rb
@@ -1,0 +1,39 @@
+class CreateFundingOpportunityTool < ApplicationTool
+  tool_name "create_funding_opportunity"
+  description <<~DESC.squish
+    Create a funding opportunity (left unapproved for an editor to review).
+    Research details from the web yourself, then call this to persist them.
+  DESC
+
+  arguments do
+    required(:title).filled(:string)
+    required(:organization).filled(:string)
+    required(:deadline).filled(:string).description("Application deadline as YYYY-MM-DD")
+    optional(:url).filled(:string).description("Link to the opportunity")
+    optional(:amount).filled(:integer).description("Award amount in euro")
+    optional(:description).filled(:string)
+    optional(:categories).filled(:string).description("Comma-separated categories")
+  end
+
+  def call(title:, organization:, deadline:, url: nil, amount: nil, description: nil, categories: nil)
+    parsed_deadline = parse_date(deadline)
+    return "Invalid deadline #{deadline.inspect}; use YYYY-MM-DD." if parsed_deadline.nil?
+
+    funding = FundingOpportunity.create!(
+      title: title, organization: organization, deadline: parsed_deadline,
+      url: url, amount: amount, description: description, categories: categories,
+      created_by: owner_user, approved: false
+    )
+    "Created funding opportunity ##{funding.id}: #{funding.title} (pending approval)."
+  rescue ActiveRecord::RecordInvalid => e
+    "Could not create funding opportunity: #{e.record.errors.full_messages.join(', ')}"
+  end
+
+  private
+
+  def parse_date(value)
+    Date.parse(value.to_s)
+  rescue ArgumentError
+    nil
+  end
+end

--- a/app/tools/create_newsletter_tool.rb
+++ b/app/tools/create_newsletter_tool.rb
@@ -1,0 +1,20 @@
+class CreateNewsletterTool < ApplicationTool
+  tool_name "create_newsletter"
+  description <<~DESC.squish
+    Create a draft newsletter. Compose the HTML content yourself from event,
+    booking, funding or email information in the database, then call this.
+    Use export_newsletter_to_brevo to push it to Brevo afterwards.
+  DESC
+
+  arguments do
+    required(:subject).filled(:string)
+    required(:content).filled(:string).description("Newsletter body as HTML")
+  end
+
+  def call(subject:, content:)
+    newsletter = Newsletter.create!(subject: subject, content: content)
+    "Created draft newsletter ##{newsletter.id}: #{newsletter.subject}"
+  rescue ActiveRecord::RecordInvalid => e
+    "Could not create newsletter: #{e.record.errors.full_messages.join(', ')}"
+  end
+end

--- a/app/tools/delete_todo_tool.rb
+++ b/app/tools/delete_todo_tool.rb
@@ -1,0 +1,16 @@
+class DeleteTodoTool < ApplicationTool
+  tool_name "delete_todo"
+  description "Delete a single admin todo by its id."
+
+  arguments do
+    required(:id).filled(:integer).description("The id of the todo to delete")
+  end
+
+  def call(id:)
+    todo = AdminTodo.find_by(id: id)
+    return "No todo found with id #{id}." if todo.nil?
+
+    todo.destroy
+    "Deleted todo ##{id}: #{todo.title}"
+  end
+end

--- a/app/tools/export_newsletter_to_brevo_tool.rb
+++ b/app/tools/export_newsletter_to_brevo_tool.rb
@@ -1,0 +1,33 @@
+class ExportNewsletterToBrevoTool < ApplicationTool
+  tool_name "export_newsletter_to_brevo"
+  description "Export a newsletter to Brevo as a draft campaign, creating or updating it."
+
+  arguments do
+    required(:id).filled(:integer).description("The id of the newsletter to export")
+  end
+
+  def call(id:)
+    newsletter = Newsletter.find_by(id: id)
+    return "No newsletter found with id #{id}." if newsletter.nil?
+
+    service = brevo_service
+    return "Brevo is not configured; cannot export." unless service.configured?
+
+    if newsletter.brevo_campaign_id.present?
+      service.update_campaign(newsletter.brevo_campaign_id, newsletter)
+      "Updated newsletter ##{id} in Brevo (campaign #{newsletter.brevo_campaign_id})."
+    else
+      campaign_id = service.create_campaign(newsletter)
+      newsletter.update!(brevo_campaign_id: campaign_id)
+      "Exported newsletter ##{id} to Brevo as draft campaign #{campaign_id}."
+    end
+  rescue BrevoService::ApiError => e
+    "Brevo error: #{e.message}"
+  end
+
+  private
+
+  def brevo_service
+    BrevoService.new
+  end
+end

--- a/app/tools/list_recent_payments_tool.rb
+++ b/app/tools/list_recent_payments_tool.rb
@@ -1,0 +1,24 @@
+class ListRecentPaymentsTool < ApplicationTool
+  tool_name "list_recent_payments"
+  description "List payments received in the last 30 days, optionally filtered by purpose."
+
+  arguments do
+    optional(:purpose).filled(:string).description("Filter by purpose: membership, booking, donation or other_purpose")
+  end
+
+  def call(purpose: nil)
+    payments = Payment.recent.order(paid_on: :desc)
+    payments = payments.where(purpose: purpose) if purpose.present?
+
+    return "No recent payments found." if payments.empty?
+
+    payments.map { |payment| format_line(payment) }.join("\n")
+  end
+
+  private
+
+  def format_line(payment)
+    "##{payment.id} €#{format('%.2f', payment.amount_euro)} [#{payment.purpose}] " \
+      "#{payment.user_name} <#{payment.user_email}> — #{payment.description} (#{payment.paid_on})"
+  end
+end

--- a/app/tools/list_todos_tool.rb
+++ b/app/tools/list_todos_tool.rb
@@ -1,0 +1,24 @@
+class ListTodosTool < ApplicationTool
+  tool_name "list_todos"
+  description "List admin todos with their id, priority and title. Pending only by default."
+
+  arguments do
+    optional(:include_completed).filled(:bool).description("Include completed todos as well as pending ones")
+  end
+
+  def call(include_completed: false)
+    scope = include_completed ? AdminTodo.all : AdminTodo.pending
+    todos = scope.default_order
+
+    return "There are no todos." if todos.empty?
+
+    todos.map { |todo| format_line(todo) }.join("\n")
+  end
+
+  private
+
+  def format_line(todo)
+    status = todo.completed? ? "done" : "pending"
+    "##{todo.id} [#{todo.priority}/#{status}] #{todo.title}"
+  end
+end

--- a/app/tools/list_unpaid_bookings_tool.rb
+++ b/app/tools/list_unpaid_bookings_tool.rb
@@ -1,0 +1,23 @@
+class ListUnpaidBookingsTool < ApplicationTool
+  tool_name "list_unpaid_bookings"
+  description <<~DESC.squish
+    List bookings that are unpaid and not cancelled, with the booker's email so
+    you can cross-reference them against payments before marking any as paid.
+  DESC
+
+  def call
+    bookings = Booking.unpaid.includes(:space, :user).order(:starts_at)
+
+    return "There are no unpaid bookings." if bookings.empty?
+
+    bookings.map { |booking| format_line(booking) }.join("\n")
+  end
+
+  private
+
+  def format_line(booking)
+    starts = booking.starts_at&.strftime("%Y-%m-%d %H:%M")
+    "##{booking.id} [#{booking.status}] #{booking.title} — #{booking.space.name}, #{starts}, " \
+      "#{booking.user.email_address}"
+  end
+end

--- a/app/tools/mark_booking_paid_tool.rb
+++ b/app/tools/mark_booking_paid_tool.rb
@@ -1,0 +1,17 @@
+class MarkBookingPaidTool < ApplicationTool
+  tool_name "mark_booking_paid"
+  description "Mark a booking as paid, once you have confirmed a matching payment was received."
+
+  arguments do
+    required(:id).filled(:integer).description("The id of the booking to mark paid")
+  end
+
+  def call(id:)
+    booking = Booking.find_by(id: id)
+    return "No booking found with id #{id}." if booking.nil?
+    return "Booking ##{id} is already marked paid." if booking.paid?
+
+    booking.update!(paid: true)
+    "Marked booking ##{id} (#{booking.title}) as paid."
+  end
+end

--- a/app/tools/purge_noisy_todos_tool.rb
+++ b/app/tools/purge_noisy_todos_tool.rb
@@ -1,0 +1,35 @@
+class PurgeNoisyTodosTool < ApplicationTool
+  tool_name "purge_noisy_todos"
+  description <<~DESC.squish
+    Delete pending todos that were auto-generated from noisy emails
+    (security alerts, login notifications, delivery updates, and other
+    automated noise). Pass dry_run to preview without deleting.
+  DESC
+
+  arguments do
+    optional(:dry_run).filled(:bool).description("Report what would be purged without deleting anything")
+  end
+
+  def call(dry_run: false)
+    noisy = noisy_todos
+    return "No noisy todos to purge." if noisy.empty?
+
+    titles = noisy.map { |todo| "##{todo.id} #{todo.title}" }.join("\n")
+
+    if dry_run
+      "Would purge #{noisy.size} noisy todo(s):\n#{titles}"
+    else
+      noisy.each(&:destroy)
+      "Purged #{noisy.size} noisy todo(s):\n#{titles}"
+    end
+  end
+
+  private
+
+  def noisy_todos
+    AdminTodo.pending
+      .where(source_type: "CachedEmail")
+      .includes(:source)
+      .select { |todo| todo.source&.noise? }
+  end
+end

--- a/app/tools/search_emails_tool.rb
+++ b/app/tools/search_emails_tool.rb
@@ -1,0 +1,25 @@
+class SearchEmailsTool < ApplicationTool
+  tool_name "search_emails"
+  description "Search cached inbox emails by subject, sender or summary. Returns matches with their ids."
+
+  arguments do
+    optional(:query).filled(:string).description("Text to match against subject, sender or summary")
+    optional(:include_archived).filled(:bool).description("Include archived emails as well (default false)")
+  end
+
+  def call(query: nil, include_archived: false)
+    scope = include_archived ? CachedEmail.all : CachedEmail.visible
+    emails = scope.search(query).order(received_at: :desc).limit(25)
+
+    return "No emails found." if emails.empty?
+
+    emails.map { |email| format_line(email) }.join("\n")
+  end
+
+  private
+
+  def format_line(email)
+    received = email.received_at&.strftime("%Y-%m-%d")
+    "##{email.id} [#{email.status}] #{email.from_address} — #{email.subject} (#{received})"
+  end
+end

--- a/app/tools/search_funding_opportunities_tool.rb
+++ b/app/tools/search_funding_opportunities_tool.rb
@@ -1,0 +1,27 @@
+class SearchFundingOpportunitiesTool < ApplicationTool
+  tool_name "search_funding_opportunities"
+  description "Search existing funding opportunities by text and/or category. Returns matches with their ids."
+
+  arguments do
+    optional(:query).filled(:string).description("Text to match against title, organization or description")
+    optional(:category).filled(:string).description("Filter to a single category")
+  end
+
+  def call(query: nil, category: nil)
+    scope = FundingOpportunity.all
+    scope = scope.search(query) if query.present?
+    scope = scope.by_category(category) if category.present?
+    results = scope.order(:deadline).limit(25)
+
+    return "No funding opportunities found." if results.empty?
+
+    results.map { |funding| format_line(funding) }.join("\n")
+  end
+
+  private
+
+  def format_line(funding)
+    status = funding.approved? ? "approved" : "pending"
+    "##{funding.id} [#{status}] #{funding.title} (#{funding.organization}) — deadline #{funding.deadline}"
+  end
+end

--- a/config/initializers/fast_mcp.rb
+++ b/config/initializers/fast_mcp.rb
@@ -1,0 +1,30 @@
+# frozen_string_literal: true
+
+require "fast_mcp"
+
+# Mounts a Model Context Protocol (MCP) server that exposes the admin tools in
+# app/tools to authenticated AI clients (e.g. Claude as a custom connector).
+#
+# The server is only mounted when MCP_AUTH_TOKEN is set, so it fails closed:
+# with no token configured there is no endpoint at all. Clients authenticate by
+# sending `Authorization: Bearer <MCP_AUTH_TOKEN>`.
+#
+# In production the host serving this must be present in config.hosts, because
+# fast-mcp validates the request Origin against the Rails host allowlist.
+mcp_auth_token = ENV["MCP_AUTH_TOKEN"].presence
+
+if mcp_auth_token
+  FastMcp.mount_in_rails(
+    Rails.application,
+    name: Rails.application.class.module_parent_name.underscore.dasherize,
+    version: "1.0.0",
+    authenticate: true,
+    auth_token: mcp_auth_token
+  ) do |server|
+    Rails.application.config.after_initialize do
+      server.register_tools(*ApplicationTool.descendants)
+    end
+  end
+elsif Rails.env.production?
+  Rails.logger.warn("[FastMcp] MCP_AUTH_TOKEN is not set; MCP server not mounted.")
+end

--- a/test/tools/application_tool_test.rb
+++ b/test/tools/application_tool_test.rb
@@ -1,0 +1,13 @@
+require "test_helper"
+
+class ApplicationToolTest < ActiveSupport::TestCase
+  # Guards the contract the MCP initializer relies on: tools live under
+  # ApplicationTool so `server.register_tools(*ApplicationTool.descendants)`
+  # registers them, and each advertises a name for the client.
+  test "todo tools are registered as named ApplicationTool descendants" do
+    [ ListTodosTool, DeleteTodoTool, PurgeNoisyTodosTool ].each do |tool|
+      assert_includes ApplicationTool.descendants, tool
+      assert tool.tool_name.present?, "#{tool} must declare a tool_name"
+    end
+  end
+end

--- a/test/tools/archive_email_tool_test.rb
+++ b/test/tools/archive_email_tool_test.rb
@@ -1,0 +1,28 @@
+require "test_helper"
+
+class ArchiveEmailToolTest < ActiveSupport::TestCase
+  test "archives the email with the given id" do
+    email = cached_email(subject: "Spammy digest")
+
+    output = ArchiveEmailTool.new.call(id: email.id)
+
+    assert_predicate email.reload, :archived?
+    assert_match "Spammy digest", output
+  end
+
+  test "reports when no email matches the id" do
+    assert_match(/no email found/i, ArchiveEmailTool.new.call(id: 999_999))
+  end
+
+  private
+
+  def cached_email(attrs = {})
+    CachedEmail.create!({
+      zoho_message_id: "msg_#{SecureRandom.hex(4)}",
+      zoho_folder_id: "folder_inbox",
+      from_address: "sender@example.com",
+      subject: "Test",
+      received_at: 1.hour.ago
+    }.merge(attrs))
+  end
+end

--- a/test/tools/create_event_tool_test.rb
+++ b/test/tools/create_event_tool_test.rb
@@ -1,0 +1,54 @@
+require "test_helper"
+
+class CreateEventToolTest < ActiveSupport::TestCase
+  test "creates an unpublished event owned by the owner account" do
+    assert_difference -> { Event.count }, 1 do
+      CreateEventTool.new.call(title: "Spring Show", starts_at: "2026-05-01 19:30")
+    end
+
+    event = Event.order(:created_at).last
+    assert_equal "Spring Show", event.title
+    assert_not event.published?, "MCP-created events must await publishing"
+    assert_equal users(:owner), event.user
+    assert_equal Time.zone.parse("2026-05-01 19:30"), event.starts_at
+  end
+
+  test "copies the first image attachment from a source email" do
+    email = cached_email
+    email.attachments.attach(io: StringIO.new("fake-png"), filename: "poster.png", content_type: "image/png")
+
+    CreateEventTool.new.call(title: "With Poster", starts_at: "2026-05-01 19:30", from_email_id: email.id)
+
+    event = Event.order(:created_at).last
+    assert event.image.attached?
+    assert_equal "poster.png", event.image.filename.to_s
+  end
+
+  test "ignores non-image attachments when sourcing an image" do
+    email = cached_email
+    email.attachments.attach(io: StringIO.new("data"), filename: "notes.pdf", content_type: "application/pdf")
+
+    CreateEventTool.new.call(title: "No Poster", starts_at: "2026-05-01 19:30", from_email_id: email.id)
+
+    assert_not Event.order(:created_at).last.image.attached?
+  end
+
+  test "rejects an unparseable start time without creating an event" do
+    assert_no_difference -> { Event.count } do
+      output = CreateEventTool.new.call(title: "Bad", starts_at: "not-a-time")
+      assert_match(/invalid start/i, output)
+    end
+  end
+
+  private
+
+  def cached_email(attrs = {})
+    CachedEmail.create!({
+      zoho_message_id: "msg_#{SecureRandom.hex(4)}",
+      zoho_folder_id: "folder_inbox",
+      from_address: "sender@example.com",
+      subject: "Test",
+      received_at: 1.hour.ago
+    }.merge(attrs))
+  end
+end

--- a/test/tools/create_funding_opportunity_tool_test.rb
+++ b/test/tools/create_funding_opportunity_tool_test.rb
@@ -1,0 +1,39 @@
+require "test_helper"
+
+class CreateFundingOpportunityToolTest < ActiveSupport::TestCase
+  test "creates a pending opportunity attributed to the owner" do
+    assert_difference -> { FundingOpportunity.count }, 1 do
+      CreateFundingOpportunityTool.new.call(
+        title: "New Bursary",
+        organization: "Arts Council",
+        deadline: "2026-12-01",
+        url: "https://example.com/apply",
+        amount: 5000,
+        description: "A grant for community arts.",
+        categories: "arts, community"
+      )
+    end
+
+    funding = FundingOpportunity.order(:created_at).last
+    assert_equal "New Bursary", funding.title
+    assert_equal Date.new(2026, 12, 1), funding.deadline
+    assert_not funding.approved, "MCP-created opportunities must await approval"
+    assert_equal users(:owner), funding.created_by
+  end
+
+  test "rejects an unparseable deadline without creating a record" do
+    assert_no_difference -> { FundingOpportunity.count } do
+      output = CreateFundingOpportunityTool.new.call(
+        title: "Bad", organization: "Org", deadline: "not-a-date"
+      )
+      assert_match(/invalid deadline/i, output)
+    end
+  end
+
+  test "returns validation errors for an invalid url" do
+    output = CreateFundingOpportunityTool.new.call(
+      title: "Bad URL", organization: "Org", deadline: "2026-12-01", url: "ftp://nope"
+    )
+    assert_match(/url/i, output)
+  end
+end

--- a/test/tools/create_newsletter_tool_test.rb
+++ b/test/tools/create_newsletter_tool_test.rb
@@ -1,0 +1,14 @@
+require "test_helper"
+
+class CreateNewsletterToolTest < ActiveSupport::TestCase
+  test "creates a draft newsletter from subject and content" do
+    assert_difference -> { Newsletter.count }, 1 do
+      CreateNewsletterTool.new.call(subject: "July News", content: "<h2>Hello</h2>")
+    end
+
+    newsletter = Newsletter.order(:created_at).last
+    assert_equal "July News", newsletter.subject
+    assert_predicate newsletter, :draft?
+    assert_match "Hello", newsletter.content.to_plain_text
+  end
+end

--- a/test/tools/delete_todo_tool_test.rb
+++ b/test/tools/delete_todo_tool_test.rb
@@ -1,0 +1,24 @@
+require "test_helper"
+
+class DeleteTodoToolTest < ActiveSupport::TestCase
+  test "deletes the todo with the given id" do
+    todo = AdminTodo.create!(title: "Bad item")
+
+    assert_difference -> { AdminTodo.count }, -1 do
+      output = DeleteTodoTool.new.call(id: todo.id)
+      assert_match "Bad item", output
+    end
+    assert_nil AdminTodo.find_by(id: todo.id)
+  end
+
+  test "reports when no todo matches the id" do
+    output = DeleteTodoTool.new.call(id: 999_999)
+    assert_match(/no todo found/i, output)
+  end
+
+  test "rejects a missing id through schema validation" do
+    assert_raises(FastMcp::Tool::InvalidArgumentsError) do
+      DeleteTodoTool.new.call_with_schema_validation!
+    end
+  end
+end

--- a/test/tools/export_newsletter_to_brevo_tool_test.rb
+++ b/test/tools/export_newsletter_to_brevo_tool_test.rb
@@ -1,0 +1,70 @@
+require "test_helper"
+
+class ExportNewsletterToBrevoToolTest < ActiveSupport::TestCase
+  # Fakes the Brevo API collaborator at its boundary (mirrors the approach in
+  # BrevoServiceTest) so the test exercises the tool's orchestration, not the
+  # external HTTP call.
+  class FakeBrevo
+    attr_reader :created, :updated
+
+    def initialize(configured:, create_id: nil)
+      @configured = configured
+      @create_id = create_id
+    end
+
+    def configured?
+      @configured
+    end
+
+    def create_campaign(newsletter)
+      @created = newsletter
+      @create_id
+    end
+
+    def update_campaign(campaign_id, newsletter)
+      @updated = [ campaign_id, newsletter ]
+      campaign_id
+    end
+  end
+
+  test "exports a new newsletter and stores the returned campaign id" do
+    newsletter = Newsletter.create!(subject: "S", content: "<p>c</p>")
+
+    output = tool_with(FakeBrevo.new(configured: true, create_id: 555)).call(id: newsletter.id)
+
+    assert_equal 555, newsletter.reload.brevo_campaign_id
+    assert_match "555", output
+  end
+
+  test "updates an already-exported newsletter instead of creating a new campaign" do
+    newsletter = Newsletter.create!(subject: "S", content: "<p>c</p>", brevo_campaign_id: 42)
+    fake = FakeBrevo.new(configured: true)
+
+    output = tool_with(fake).call(id: newsletter.id)
+
+    assert_equal 42, fake.updated.first
+    assert_nil fake.created
+    assert_match(/updated/i, output)
+  end
+
+  test "does nothing when Brevo is not configured" do
+    newsletter = Newsletter.create!(subject: "S", content: "<p>c</p>")
+
+    output = tool_with(FakeBrevo.new(configured: false)).call(id: newsletter.id)
+
+    assert_nil newsletter.reload.brevo_campaign_id
+    assert_match(/not configured/i, output)
+  end
+
+  test "reports when the newsletter is missing" do
+    assert_match(/no newsletter found/i, ExportNewsletterToBrevoTool.new.call(id: 999_999))
+  end
+
+  private
+
+  def tool_with(fake)
+    tool = ExportNewsletterToBrevoTool.new
+    tool.define_singleton_method(:brevo_service) { fake }
+    tool
+  end
+end

--- a/test/tools/list_recent_payments_tool_test.rb
+++ b/test/tools/list_recent_payments_tool_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class ListRecentPaymentsToolTest < ActiveSupport::TestCase
+  test "lists recent payments and can filter by purpose" do
+    membership = memberships(:active_membership)
+    booking_payment = create_payment(membership, description: "Room hire", purpose: :booking,
+                                      user_email: "editor@example.com")
+    membership_payment = create_payment(membership, description: "Annual dues", purpose: :membership,
+                                        user_email: "someone@example.com")
+
+    all = ListRecentPaymentsTool.new.call
+    assert_match "##{booking_payment.id}", all
+    assert_match "editor@example.com", all
+
+    only_bookings = ListRecentPaymentsTool.new.call(purpose: "booking")
+    assert_match "##{booking_payment.id}", only_bookings
+    assert_no_match(/##{membership_payment.id}\b/, only_bookings)
+  end
+
+  private
+
+  def create_payment(membership, attrs = {})
+    Payment.create!({
+      membership: membership,
+      amount_cents: 5000,
+      description: "Payment",
+      paid_on: Date.current,
+      payment_method: :cash,
+      user_email: "payer@example.com",
+      user_name: "Payer"
+    }.merge(attrs))
+  end
+end

--- a/test/tools/list_todos_tool_test.rb
+++ b/test/tools/list_todos_tool_test.rb
@@ -1,0 +1,27 @@
+require "test_helper"
+
+class ListTodosToolTest < ActiveSupport::TestCase
+  test "lists pending todos with id, priority and title" do
+    todo = AdminTodo.create!(title: "Call the council", priority: :high)
+    AdminTodo.create!(title: "Done thing", completed: true)
+
+    output = ListTodosTool.new.call
+
+    assert_match "Call the council", output
+    assert_match todo.id.to_s, output
+    assert_match "high", output
+    assert_no_match(/Done thing/, output)
+  end
+
+  test "includes completed todos when requested" do
+    AdminTodo.create!(title: "Done thing", completed: true)
+
+    output = ListTodosTool.new.call(include_completed: true)
+
+    assert_match "Done thing", output
+  end
+
+  test "reports when there are no todos" do
+    assert_match(/no .*todos/i, ListTodosTool.new.call)
+  end
+end

--- a/test/tools/list_unpaid_bookings_tool_test.rb
+++ b/test/tools/list_unpaid_bookings_tool_test.rb
@@ -1,0 +1,20 @@
+require "test_helper"
+
+class ListUnpaidBookingsToolTest < ActiveSupport::TestCase
+  test "lists unpaid, non-cancelled bookings with the booker email" do
+    paid = bookings(:upcoming_booking)
+    paid.update!(paid: true)
+    unpaid = bookings(:pending_booking)
+
+    output = ListUnpaidBookingsTool.new.call
+
+    assert_match "##{unpaid.id}", output
+    assert_match unpaid.user.email_address, output
+    assert_no_match(/##{paid.id}\b/, output)
+  end
+
+  test "reports when there are no unpaid bookings" do
+    Booking.update_all(paid: true)
+    assert_match(/no unpaid bookings/i, ListUnpaidBookingsTool.new.call)
+  end
+end

--- a/test/tools/mark_booking_paid_tool_test.rb
+++ b/test/tools/mark_booking_paid_tool_test.rb
@@ -1,0 +1,25 @@
+require "test_helper"
+
+class MarkBookingPaidToolTest < ActiveSupport::TestCase
+  test "marks an unpaid booking as paid" do
+    booking = bookings(:pending_booking)
+
+    output = MarkBookingPaidTool.new.call(id: booking.id)
+
+    assert_predicate booking.reload, :paid?
+    assert_match(/marked/i, output)
+  end
+
+  test "notes when the booking is already paid" do
+    booking = bookings(:upcoming_booking)
+    booking.update!(paid: true)
+
+    output = MarkBookingPaidTool.new.call(id: booking.id)
+
+    assert_match(/already/i, output)
+  end
+
+  test "reports when no booking matches the id" do
+    assert_match(/no booking found/i, MarkBookingPaidTool.new.call(id: 999_999))
+  end
+end

--- a/test/tools/purge_noisy_todos_tool_test.rb
+++ b/test/tools/purge_noisy_todos_tool_test.rb
@@ -1,0 +1,46 @@
+require "test_helper"
+
+class PurgeNoisyTodosToolTest < ActiveSupport::TestCase
+  test "deletes todos whose source email is noise and keeps the rest" do
+    noisy = cached_email(subject: "Security Alert: Verify a new IP")
+    signal = cached_email(subject: "Mayo Culture Night Event Fund now Open For Applications")
+    noisy_todo = AdminTodo.create!(noisy.to_admin_todo_attrs)
+    signal_todo = AdminTodo.create!(signal.to_admin_todo_attrs)
+
+    output = PurgeNoisyTodosTool.new.call
+
+    assert_nil AdminTodo.find_by(id: noisy_todo.id)
+    assert AdminTodo.find_by(id: signal_todo.id), "must keep todos sourced from genuine email"
+    assert_match "1", output
+  end
+
+  test "dry run reports what would be purged without deleting" do
+    noisy = cached_email(subject: "Your package is out for delivery")
+    noisy_todo = AdminTodo.create!(noisy.to_admin_todo_attrs)
+
+    output = PurgeNoisyTodosTool.new.call(dry_run: true)
+
+    assert AdminTodo.find_by(id: noisy_todo.id), "dry run must not delete"
+    assert_match(/would/i, output)
+  end
+
+  test "ignores manually-added todos that have no source email" do
+    manual = AdminTodo.create!(title: "Hand-written task")
+
+    PurgeNoisyTodosTool.new.call
+
+    assert AdminTodo.find_by(id: manual.id)
+  end
+
+  private
+
+  def cached_email(attrs = {})
+    CachedEmail.create!({
+      zoho_message_id: "msg_#{SecureRandom.hex(4)}",
+      zoho_folder_id: "folder_inbox",
+      from_address: "sender@example.com",
+      subject: "Test",
+      received_at: 1.hour.ago
+    }.merge(attrs))
+  end
+end

--- a/test/tools/search_emails_tool_test.rb
+++ b/test/tools/search_emails_tool_test.rb
@@ -1,0 +1,38 @@
+require "test_helper"
+
+class SearchEmailsToolTest < ActiveSupport::TestCase
+  test "matches emails by subject, sender or summary and includes their id" do
+    match = cached_email(subject: "Exhibition opening night", from_address: "gallery@example.com")
+    cached_email(subject: "Unrelated invoice", from_address: "billing@example.com")
+
+    output = SearchEmailsTool.new.call(query: "exhibition")
+
+    assert_match "##{match.id}", output
+    assert_match "Exhibition opening night", output
+    assert_no_match(/Unrelated invoice/, output)
+  end
+
+  test "excludes archived emails unless include_archived is set" do
+    archived = cached_email(subject: "Old exhibition", status: :archived)
+
+    assert_no_match(/##{archived.id}\b/, SearchEmailsTool.new.call(query: "exhibition"))
+    assert_match "##{archived.id}", SearchEmailsTool.new.call(query: "exhibition", include_archived: true)
+  end
+
+  test "reports when nothing matches" do
+    assert_match(/no emails/i, SearchEmailsTool.new.call(query: "nothing-matches-this"))
+  end
+
+  private
+
+  def cached_email(attrs = {})
+    CachedEmail.create!({
+      zoho_message_id: "msg_#{SecureRandom.hex(4)}",
+      zoho_folder_id: "folder_inbox",
+      from_address: "sender@example.com",
+      subject: "Test",
+      summary: "Test summary",
+      received_at: 1.hour.ago
+    }.merge(attrs))
+  end
+end

--- a/test/tools/search_funding_opportunities_tool_test.rb
+++ b/test/tools/search_funding_opportunities_tool_test.rb
@@ -1,0 +1,33 @@
+require "test_helper"
+
+class SearchFundingOpportunitiesToolTest < ActiveSupport::TestCase
+  test "matches by title, organization or description and shows approval status" do
+    match = FundingOpportunity.create!(title: "Arts Bursary 2026", organization: "Arts Council",
+                                       deadline: 1.month.from_now, approved: true)
+    FundingOpportunity.create!(title: "Sports Grant", organization: "Sport Ireland",
+                               deadline: 1.month.from_now)
+
+    output = SearchFundingOpportunitiesTool.new.call(query: "bursary")
+
+    assert_match "##{match.id}", output
+    assert_match "Arts Bursary 2026", output
+    assert_match(/approved/, output)
+    assert_no_match(/Sports Grant/, output)
+  end
+
+  test "filters by category" do
+    music = FundingOpportunity.create!(title: "Music Fund", organization: "Org",
+                                       deadline: 1.month.from_now, categories: "music, performance")
+    FundingOpportunity.create!(title: "Visual Fund", organization: "Org",
+                               deadline: 1.month.from_now, categories: "visual")
+
+    output = SearchFundingOpportunitiesTool.new.call(category: "music")
+
+    assert_match "##{music.id}", output
+    assert_no_match(/Visual Fund/, output)
+  end
+
+  test "reports when nothing matches" do
+    assert_match(/no funding/i, SearchFundingOpportunitiesTool.new.call(query: "nothing"))
+  end
+end


### PR DESCRIPTION
## Why

So an AI client (Claude as a custom connector) can act on admin data directly — remove noisy todos, triage the inbox, draft events/newsletters/funding records, and reconcile booking payments — without hand-writing SQL or console sessions.

## What

Adds the [`fast-mcp`](https://github.com/yjacquin/fast-mcp) gem and mounts a Model Context Protocol server at `/mcp` exposing an allowlist of admin tools under `app/tools`. Built in phases:

**Todos**
- `list_todos(include_completed?)`, `delete_todo(id)`, `purge_noisy_todos(dry_run?)` — the last reuses `CachedEmail#noise?` from #89

**Emails**
- `search_emails(query?, include_archived?)`, `archive_email(id)` — adds a `CachedEmail.search` scope

**Events**
- `create_event(title, starts_at, …, from_email_id?)` — builds a **draft** event owned by the owner account; optional `from_email_id` copies the first image attachment of that email into `event.image`

**Funding**
- `search_funding_opportunities(query?, category?)` (existing DB), `create_funding_opportunity(…)` — I research on the web myself, then call create; records are attributed to the owner and left **unapproved** for editor review. Adds a `FundingOpportunity.search` scope

**Newsletters**
- `create_newsletter(subject, content)`, `export_newsletter_to_brevo(id)` — reuses the existing `BrevoService`; the export tool has a `brevo_service` seam so tests fake the API boundary

**Bookings / payments (assistive, not automatic)**
- `list_unpaid_bookings`, `list_recent_payments(purpose?)`, `mark_booking_paid(id)`
- **Design note:** `Payment` has no foreign key to `Booking` (it `belongs_to :membership`), so there is no structural way to auto-match a payment to a booking. Rather than invent a heuristic that would eventually mis-mark money, these tools surface both sides for a human/AI to reconcile, then mark manually.

## Security model

- **Fails closed** — mounted only when `MCP_AUTH_TOKEN` is set; no token → no endpoint. Production without a token logs a warning and stays unmounted.
- **Bearer auth** via fast-mcp's `AuthenticatedRackTransport` (`Authorization: Bearer <MCP_AUTH_TOKEN>`).
- **Origin allowlist** against `config.hosts`; localhost-only IP gate relaxes only outside `Rails.env.local?`.
- Tools are an explicit class allowlist under `ApplicationTool`, not arbitrary SQL.
- Records created over MCP have no session user, so they are attributed to the **owner account** (`ApplicationTool#owner_user`) and creation defaults to unpublished/unapproved where a review step exists.

## Structure

- `Gemfile`: `gem "fast-mcp", require: "fast_mcp"` (lib file is `fast_mcp.rb`; without the explicit require the railtie never loads — verified on boot).
- `config/initializers/fast_mcp.rb`: token-gated mount + auto-registration of `ApplicationTool.descendants`.
- `app/tools/`: `ApplicationTool` base + 13 tools.
- Model additions: `CachedEmail.search`, `FundingOpportunity.search` scopes.

## Tests

Every tool is a plain object exercised directly against real `AdminTodo`/`CachedEmail`/`Event`/`FundingOpportunity`/`Newsletter`/`Booking`/`Payment` records (real ActiveStorage for image copy; the only fake is the external Brevo client at its boundary). `application_tool_test` guards the registration contract.

Full suite: **730 runs, 0 failures.** Rubocop clean, Brakeman 0 warnings.

## To use it

1. Set `MCP_AUTH_TOKEN` (and ensure the prod host is in `config.hosts`).
2. Add as a custom MCP connector at `https://<host>/mcp/sse` with the bearer token header.

## Notes / follow-ups

- Bearer-token MCP works directly with Claude Code / desktop clients; claude.ai *web* custom connectors generally expect OAuth, which would be a separate, larger change.
- Branch name is inherited from the prior (merged) todo work per the branch convention.

🤖 Generated with [Claude Code](https://claude.com/claude-code)