### PR TITLE
Add resource API + claude.ai MCP connector

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -69,6 +69,10 @@ gem "brevo"
 # Forum engine [https://github.com/thredded/thredded]
 gem "thredded"
 
+# MCP server + OAuth 2.1 provider for the claude.ai web connector
+gem "mcp"
+gem "doorkeeper"
+
 group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -146,6 +146,8 @@ GEM
       reline (>= 0.3.8)
     dockerfile-rails (1.7.10)
       rails (>= 3.0.0)
+    doorkeeper (5.9.3)
+      railties (>= 5)
     dotenv (3.2.0)
     drb (2.2.3)
     ed25519 (1.4.0)
@@ -181,6 +183,7 @@ GEM
       raabro (~> 1.4)
     globalid (1.3.0)
       activesupport (>= 6.1)
+    hana (1.3.7)
     hashdiff (1.2.1)
     html-pipeline (2.14.3)
       activesupport (>= 2)
@@ -215,6 +218,11 @@ GEM
       activesupport (>= 7.0.0)
     jmespath (1.6.2)
     json (2.20.0)
+    json_schemer (2.5.0)
+      bigdecimal
+      hana (~> 1.3)
+      regexp_parser (~> 2.0)
+      simpleidn (~> 0.2)
     kamal (2.12.0)
       activesupport (>= 7.0)
       base64 (~> 0.2)
@@ -286,6 +294,8 @@ GEM
       net-smtp
     marcel (1.1.0)
     matrix (0.4.3)
+    mcp (0.22.0)
+      json_schemer (>= 2.4)
     mini_magick (5.3.1)
       logger
     mini_mime (1.1.5)
@@ -488,6 +498,7 @@ GEM
       bigdecimal
       concurrent-ruby (~> 1.0, >= 1.0.2)
       logger
+    simpleidn (0.2.3)
     solid_cable (3.0.12)
       actioncable (>= 7.2)
       activejob (>= 7.2)
@@ -617,6 +628,7 @@ DEPENDENCIES
   csv
   debug
   dockerfile-rails (>= 1.7)
+  doorkeeper
   dotenv (~> 3.2)
   faraday
   icalendar
@@ -626,6 +638,7 @@ DEPENDENCIES
   kamal
   lexxy
   litestream (~> 0.14.0)
+  mcp
   mission_control-jobs (~> 1.1)
   pagy
   propshaft
@@ -698,6 +711,7 @@ CHECKSUMS
   db_text_search (1.0.0) sha256=4cad83819a02e7e225174ab059de8087fcb68ed88e5926448aae63ef1769406b
   debug (1.11.1) sha256=2e0b0ac6119f2207a6f8ac7d4a73ca8eb4e440f64da0a3136c30343146e952b6
   dockerfile-rails (1.7.10) sha256=04163273792ec6c6560244d32c0b44bbed705384a47b8063adcbf0d7bc8abd26
+  doorkeeper (5.9.3) sha256=e6d120235bd134494bd02d08e8063c994fc1a58a681285077e671529bfc5d90b
   dotenv (3.2.0) sha256=e375b83121ea7ca4ce20f214740076129ab8514cd81378161f11c03853fe619d
   drb (2.2.3) sha256=0b00d6fdb50995fe4a45dea13663493c841112e4068656854646f418fda13373
   ed25519 (1.4.0) sha256=16e97f5198689a154247169f3453ef4cfd3f7a47481fde0ae33206cdfdcac506
@@ -721,6 +735,7 @@ CHECKSUMS
   friendly_id (5.6.0) sha256=28e221cd53fbd21586321164c1c6fd0c9ba8dde13969cb2363679f44726bb0c3
   fugit (1.12.1) sha256=5898f478ede9b415f0804e42b8f3fd53f814bd85eebffceebdbc34e1107aaf68
   globalid (1.3.0) sha256=05c639ad6eb4594522a0b07983022f04aa7254626ab69445a0e493aa3786ff11
+  hana (1.3.7) sha256=5425db42d651fea08859811c29d20446f16af196308162894db208cac5ce9b0d
   hashdiff (1.2.1) sha256=9c079dbc513dfc8833ab59c0c2d8f230fa28499cc5efb4b8dd276cf931457cd1
   html-pipeline (2.14.3) sha256=8a1d4d7128b2141913387cac0f8ba898bb6812557001acc0c2b46910f59413a0
   htmlentities (4.4.2) sha256=bbafbdf69f2eca9262be4efef7e43e6a1de54c95eb600f26984f71d2fe96c5c3
@@ -735,6 +750,7 @@ CHECKSUMS
   jbuilder (2.14.1) sha256=4eb26376ff60ef100cb4fd6fd7533cd271f9998327e86adf20fd8c0e69fabb42
   jmespath (1.6.2) sha256=238d774a58723d6c090494c8879b5e9918c19485f7e840f2c1c7532cf84ebcb1
   json (2.20.0) sha256=9362bc6e55a952b056abf9167cf053358181c904cb70cd6eee0808ea830fc32b
+  json_schemer (2.5.0) sha256=2f01fb4cce721a4e08dd068fc2030cffd0702a7f333f1ea2be6e8991f00ae396
   kamal (2.12.0) sha256=c51d1ab085e515470f98d0c0f043637122b5ebf76e8b610cb1fbbed0b7f9b8fa
   kaminari (1.2.2) sha256=c4076ff9adccc6109408333f87b5c4abbda5e39dc464bd4c66d06d9f73442a3e
   kaminari-actionview (1.2.2) sha256=1330f6fc8b59a4a4ef6a549ff8a224797289ebf7a3a503e8c1652535287cc909
@@ -754,6 +770,7 @@ CHECKSUMS
   mail (2.9.0) sha256=6fa6673ecd71c60c2d996260f9ee3dd387d4673b8169b502134659ece6d34941
   marcel (1.1.0) sha256=fdcfcfa33cc52e93c4308d40e4090a5d4ea279e160a7f6af988260fa970e0bee
   matrix (0.4.3) sha256=a0d5ab7ddcc1973ff690ab361b67f359acbb16958d1dc072b8b956a286564c5b
+  mcp (0.22.0) sha256=e2ef603207c7e2c691bef4d8d8ab35d9740bedf315949fdb6d9a25318d1a7025
   mini_magick (5.3.1) sha256=29395dfd76badcabb6403ee5aff6f681e867074f8f28ce08d78661e9e4a351c4
   mini_mime (1.1.5) sha256=8681b7e2e4215f2a159f9400b5816d85e9d8c6c6b491e96a12797e798f8bccef
   minitest (6.0.6) sha256=153ea36d1d987a62942382b61075745042a2b3123b1cd48f4c3675af9cc7d6f1
@@ -828,6 +845,7 @@ CHECKSUMS
   selenium-webdriver (4.43.0) sha256=a634377b964b701c6ac0a009ce3a08fa34ec1e1e7fe9a6d57e3088d14529a65c
   sentry-rails (6.5.0) sha256=ebf9d4d82c740c3e0e4a0840f11f7bbd0cf648a30afd9c67e5b50bb07018a0e4
   sentry-ruby (6.5.0) sha256=3c57ae0d6a017aafcd9ac37114e38149a58534679dec5d4e9e8fc010b85f3a6b
+  simpleidn (0.2.3) sha256=08ce96f03fa1605286be22651ba0fc9c0b2d6272c9b27a260bc88be05b0d2c29
   solid_cable (3.0.12) sha256=a168a54731a455d5627af48d8441ea3b554b8c1f6e6cd6074109de493e6b0460
   solid_cache (1.0.10) sha256=bc05a2fb3ac78a6f43cbb5946679cf9db67dd30d22939ededc385cb93e120d41
   solid_queue (1.3.2) sha256=44a53047be4255f616ff13fa5d35980e7b3eee6e31d957eadb88fbe8e0db4509

--- a/app/controllers/api/v1/admin_todos_controller.rb
+++ b/app/controllers/api/v1/admin_todos_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  module V1
+    class AdminTodosController < ResourceController
+      permits :title, :description, :completed, :due_date, :position, :priority,
+              :source_id, :source_type
+    end
+  end
+end

--- a/app/controllers/api/v1/base_controller.rb
+++ b/app/controllers/api/v1/base_controller.rb
@@ -1,0 +1,33 @@
+module Api
+  module V1
+    # Base for the JSON API. Authenticates every request with a single bearer
+    # token (Rails' native HTTP token auth) and renders JSON errors instead of
+    # HTML redirects. No cookie session or CSRF — the token is the only credential.
+    class BaseController < ActionController::API
+      include ActionController::HttpAuthentication::Token::ControllerMethods
+
+      before_action :authenticate_api_token
+
+      rescue_from ActiveRecord::RecordNotFound do |error|
+        render json: { error: error.message }, status: :not_found
+      end
+
+      rescue_from ActionController::ParameterMissing do |error|
+        render json: { error: error.message }, status: :bad_request
+      end
+
+      private
+
+      def authenticate_api_token
+        authenticate_or_request_with_http_token do |token, _options|
+          expected = self.class.api_token
+          expected.present? && ActiveSupport::SecurityUtils.secure_compare(token, expected)
+        end
+      end
+
+      def self.api_token
+        Rails.application.credentials.api_token || ENV["API_TOKEN"]
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/bookings_controller.rb
+++ b/app/controllers/api/v1/bookings_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  module V1
+    class BookingsController < ResourceController
+      permits :title, :description, :starts_at, :ends_at, :status, :paid, :space_id, :user_id,
+              :approved_at, :approved_by_id
+    end
+  end
+end

--- a/app/controllers/api/v1/email_groups_controller.rb
+++ b/app/controllers/api/v1/email_groups_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class EmailGroupsController < ResourceController
+      permits :name, :local_part, :description, :active
+    end
+  end
+end

--- a/app/controllers/api/v1/events_controller.rb
+++ b/app/controllers/api/v1/events_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class EventsController < ResourceController
+      permits :title, :description, :rich_description, :bio, :capacity, :doors_at, :starts_at,
+              :ends_at, :links, :published, :ticket_price_cents, :ticket_url, :ticketing_enabled,
+              :tickets_available_from, :venue_address, :venue_name, :user_id
+    end
+  end
+end

--- a/app/controllers/api/v1/faqs_controller.rb
+++ b/app/controllers/api/v1/faqs_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class FaqsController < ResourceController
+      permits :question, :answer, :order, :active
+    end
+  end
+end

--- a/app/controllers/api/v1/funding_opportunities_controller.rb
+++ b/app/controllers/api/v1/funding_opportunities_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  module V1
+    class FundingOpportunitiesController < ResourceController
+      permits :title, :organization, :amount, :categories, :deadline, :description, :url,
+              :approved, :created_by_id
+    end
+  end
+end

--- a/app/controllers/api/v1/memberships_controller.rb
+++ b/app/controllers/api/v1/memberships_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class MembershipsController < ResourceController
+      permits :membership_type, :starts_on, :expires_on, :notes, :user_id
+    end
+  end
+end

--- a/app/controllers/api/v1/newsletters_controller.rb
+++ b/app/controllers/api/v1/newsletters_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class NewslettersController < ResourceController
+      permits :subject, :status, :sent_at, :brevo_campaign_id, :chat_id, :content
+    end
+  end
+end

--- a/app/controllers/api/v1/pages_controller.rb
+++ b/app/controllers/api/v1/pages_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class PagesController < ResourceController
+      permits :title, :slug, :locale, :nav_location, :visibility, :content
+    end
+  end
+end

--- a/app/controllers/api/v1/payments_controller.rb
+++ b/app/controllers/api/v1/payments_controller.rb
@@ -1,0 +1,9 @@
+module Api
+  module V1
+    class PaymentsController < ResourceController
+      permits :amount_cents, :description, :notes, :paid_on, :payment_method, :purpose, :status,
+              :user_email, :user_name, :membership_id, :pending_membership_type,
+              :sumup_checkout_id, :sumup_transaction_id
+    end
+  end
+end

--- a/app/controllers/api/v1/posts_controller.rb
+++ b/app/controllers/api/v1/posts_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class PostsController < ResourceController
+      permits :title, :slug, :excerpt, :post_type, :published, :published_at, :user_id, :body
+    end
+  end
+end

--- a/app/controllers/api/v1/profiles_controller.rb
+++ b/app/controllers/api/v1/profiles_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class ProfilesController < ResourceController
+      permits :name, :bio, :location, :skills, :website, :visible, :public_gallery, :user_id
+    end
+  end
+end

--- a/app/controllers/api/v1/proposals_controller.rb
+++ b/app/controllers/api/v1/proposals_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  module V1
+    class ProposalsController < ResourceController
+      permits :title, :description, :amount_requested, :organizer_fee, :status, :submission_deadline,
+              :submitted_at, :reviewed_at, :admin_notes, :funding_opportunity_id, :user_id
+    end
+  end
+end

--- a/app/controllers/api/v1/resource_controller.rb
+++ b/app/controllers/api/v1/resource_controller.rb
@@ -69,21 +69,8 @@ module Api
         render json: { errors: record.errors.full_messages }, status: :unprocessable_entity
       end
 
-      # Serialize DB columns plus any ActionText rich-text fields (as HTML).
       def serialize(record)
-        record.attributes.merge(rich_text_fields(record))
-      end
-
-      def rich_text_fields(record)
-        rich_text_names(record.class).index_with do |name|
-          record.public_send(name)&.body&.to_html
-        end
-      end
-
-      def rich_text_names(klass)
-        klass.reflect_on_all_associations(:has_one)
-             .select { |assoc| assoc.options[:class_name].to_s == "ActionText::RichText" }
-             .map { |assoc| assoc.name.to_s.delete_prefix("rich_text_") }
+        Api::RecordSerializer.call(record)
       end
     end
   end

--- a/app/controllers/api/v1/resource_controller.rb
+++ b/app/controllers/api/v1/resource_controller.rb
@@ -1,0 +1,90 @@
+module Api
+  module V1
+    # Generic read/create/update controller. Each resource subclass declares only
+    # its writable attributes via #permitted_attributes; the model and param key
+    # are inferred from the controller name by Rails convention (FaqsController →
+    # Faq, :faq). Deliberately no #destroy — deletion stays in the admin UI.
+    class ResourceController < BaseController
+      class_attribute :permitted_attributes, instance_writer: false, default: []
+
+      before_action :set_record, only: [ :show, :update ]
+
+      # Declares the attributes writable through the API and wires parameter
+      # wrapping to include them — so a flat JSON body ({"question": ...}) is
+      # wrapped correctly, including rich-text fields that aren't DB columns and
+      # would otherwise be silently dropped.
+      def self.permits(*attributes)
+        self.permitted_attributes = attributes
+        wrap_parameters controller_name.singularize.to_sym, include: attributes.map(&:to_s)
+      end
+
+      def index
+        render json: resource_scope.map { |record| serialize(record) }
+      end
+
+      def show
+        render json: serialize(@record)
+      end
+
+      def create
+        record = resource_class.new(resource_params)
+        if record.save
+          render json: serialize(record), status: :created
+        else
+          render_errors(record)
+        end
+      end
+
+      def update
+        if @record.update(resource_params)
+          render json: serialize(@record)
+        else
+          render_errors(@record)
+        end
+      end
+
+      private
+
+      def resource_class
+        controller_name.classify.constantize
+      end
+
+      def resource_scope
+        resource_class.all
+      end
+
+      def set_record
+        @record = resource_scope.find(params[:id])
+      end
+
+      def resource_params
+        params.require(param_key).permit(*permitted_attributes)
+      end
+
+      def param_key
+        controller_name.singularize.to_sym
+      end
+
+      def render_errors(record)
+        render json: { errors: record.errors.full_messages }, status: :unprocessable_entity
+      end
+
+      # Serialize DB columns plus any ActionText rich-text fields (as HTML).
+      def serialize(record)
+        record.attributes.merge(rich_text_fields(record))
+      end
+
+      def rich_text_fields(record)
+        rich_text_names(record.class).index_with do |name|
+          record.public_send(name)&.body&.to_html
+        end
+      end
+
+      def rich_text_names(klass)
+        klass.reflect_on_all_associations(:has_one)
+             .select { |assoc| assoc.options[:class_name].to_s == "ActionText::RichText" }
+             .map { |assoc| assoc.name.to_s.delete_prefix("rich_text_") }
+      end
+    end
+  end
+end

--- a/app/controllers/api/v1/spaces_controller.rb
+++ b/app/controllers/api/v1/spaces_controller.rb
@@ -1,0 +1,7 @@
+module Api
+  module V1
+    class SpacesController < ResourceController
+      permits :name, :description, :capacity, :active, :component_of_id
+    end
+  end
+end

--- a/app/controllers/api/v1/tickets_controller.rb
+++ b/app/controllers/api/v1/tickets_controller.rb
@@ -1,0 +1,8 @@
+module Api
+  module V1
+    class TicketsController < ResourceController
+      permits :buyer_name, :buyer_email, :quantity, :amount_cents, :status, :event_id,
+              :sumup_checkout_id, :sumup_transaction_id
+    end
+  end
+end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,15 +1,9 @@
 module Api
   module V1
     class UsersController < ResourceController
-      # Deliberately excludes :role (no privilege escalation via the API) and
-      # never exposes the password digest.
+      # Deliberately excludes :role (no privilege escalation via the API). The
+      # password digest is stripped by Api::RecordSerializer for every resource.
       permits :email_address, :approved, :password, :password_confirmation
-
-      private
-
-      def serialize(record)
-        super.except("password_digest")
-      end
     end
   end
 end

--- a/app/controllers/api/v1/users_controller.rb
+++ b/app/controllers/api/v1/users_controller.rb
@@ -1,0 +1,15 @@
+module Api
+  module V1
+    class UsersController < ResourceController
+      # Deliberately excludes :role (no privilege escalation via the API) and
+      # never exposes the password digest.
+      permits :email_address, :approved, :password, :password_confirmation
+
+      private
+
+      def serialize(record)
+        super.except("password_digest")
+      end
+    end
+  end
+end

--- a/app/controllers/mcp_controller.rb
+++ b/app/controllers/mcp_controller.rb
@@ -1,0 +1,38 @@
+# The MCP endpoint for the claude.ai connector. Stateless Streamable HTTP:
+# Claude POSTs JSON-RPC, we hand it to the MCP server and return its JSON.
+# Protected by a Doorkeeper access token carrying the mcp:access scope.
+class McpController < ActionController::Base
+  skip_forgery_protection
+  before_action :require_mcp_token
+
+  def invoke
+    unless request.post?
+      response.set_header("Allow", "POST")
+      return head(:method_not_allowed)
+    end
+
+    result = mcp_server.handle_json(request.body.read)
+    if result
+      render json: result
+    else
+      head :accepted
+    end
+  end
+
+  private
+
+  def mcp_server
+    Mcp::Server.build(current_resource_owner)
+  end
+
+  def current_resource_owner
+    User.find_by(id: doorkeeper_token&.resource_owner_id)
+  end
+
+  def require_mcp_token
+    return if doorkeeper_token&.acceptable?("mcp:access")
+
+    response.set_header("WWW-Authenticate", %(Bearer resource_metadata="#{oauth_protected_resource_url}"))
+    render json: { error: "invalid_token" }, status: :unauthorized
+  end
+end

--- a/app/controllers/oauth/metadata_controller.rb
+++ b/app/controllers/oauth/metadata_controller.rb
@@ -1,0 +1,29 @@
+module Oauth
+  # Publishes the OAuth 2.1 discovery documents Claude fetches before connecting:
+  # RFC 8414 authorization-server metadata and RFC 9728 protected-resource metadata.
+  class MetadataController < ActionController::Base
+    def authorization_server
+      render json: {
+        issuer: request.base_url,
+        authorization_endpoint: oauth_authorization_url,
+        token_endpoint: oauth_token_url,
+        registration_endpoint: oauth_register_url,
+        revocation_endpoint: oauth_revoke_url,
+        response_types_supported: %w[code],
+        grant_types_supported: %w[authorization_code refresh_token],
+        token_endpoint_auth_methods_supported: %w[none],
+        code_challenge_methods_supported: %w[S256],
+        scopes_supported: %w[mcp:access]
+      }
+    end
+
+    def protected_resource
+      render json: {
+        resource: mcp_url,
+        authorization_servers: [ request.base_url ],
+        bearer_methods_supported: %w[header],
+        scopes_supported: %w[mcp:access]
+      }
+    end
+  end
+end

--- a/app/controllers/oauth/registrations_controller.rb
+++ b/app/controllers/oauth/registrations_controller.rb
@@ -1,0 +1,42 @@
+module Oauth
+  # RFC 7591 Dynamic Client Registration. Claude POSTs its client metadata here
+  # and we provision a public (secret-less) Doorkeeper application scoped to
+  # mcp:access. Access is granted per-user via PKCE + the authorization flow.
+  class RegistrationsController < ActionController::Base
+    skip_forgery_protection
+    rate_limit to: 10, within: 1.minute, with: :rate_limit_exceeded
+
+    def create
+      redirect_uris = Array(params[:redirect_uris]).reject(&:blank?)
+      application = Doorkeeper::Application.new(
+        name: params[:client_name].presence || "MCP Client",
+        redirect_uri: redirect_uris.join("\n"),
+        scopes: "mcp:access",
+        confidential: false
+      )
+
+      if application.save
+        render json: {
+          client_id: application.uid,
+          client_id_issued_at: application.created_at.to_i,
+          client_name: application.name,
+          redirect_uris: application.redirect_uri.split,
+          grant_types: %w[authorization_code refresh_token],
+          token_endpoint_auth_method: "none",
+          scope: "mcp:access"
+        }, status: :created
+      else
+        render json: {
+          error: "invalid_client_metadata",
+          error_description: application.errors.full_messages.join(", ")
+        }, status: :bad_request
+      end
+    end
+
+    private
+
+    def rate_limit_exceeded
+      render json: { error: "too_many_requests" }, status: :too_many_requests
+    end
+  end
+end

--- a/app/services/api/record_serializer.rb
+++ b/app/services/api/record_serializer.rb
@@ -1,0 +1,24 @@
+module Api
+  # Serializes an ActiveRecord record to a plain hash: DB columns plus any
+  # ActionText rich-text fields rendered as HTML. Never exposes password digests.
+  # Shared by the REST API and the MCP tools so both present records identically.
+  module RecordSerializer
+    module_function
+
+    def call(record)
+      record.attributes.except("password_digest").merge(rich_text_fields(record))
+    end
+
+    def rich_text_fields(record)
+      rich_text_names(record.class).index_with do |name|
+        record.public_send(name)&.body&.to_html
+      end
+    end
+
+    def rich_text_names(klass)
+      klass.reflect_on_all_associations(:has_one)
+           .select { |assoc| assoc.options[:class_name].to_s == "ActionText::RichText" }
+           .map { |assoc| assoc.name.to_s.delete_prefix("rich_text_") }
+    end
+  end
+end

--- a/app/services/mcp/resource_registry.rb
+++ b/app/services/mcp/resource_registry.rb
@@ -1,0 +1,33 @@
+module Mcp
+  # Maps the MCP-exposed resource names to their models and writable attributes.
+  # Writable attributes are read straight from the REST API controllers so the
+  # two surfaces can never drift or disagree on what's editable.
+  module ResourceRegistry
+    module_function
+
+    RESOURCES = %w[
+      faqs pages posts events newsletters funding_opportunities spaces bookings
+      memberships proposals payments tickets email_groups admin_todos profiles users
+    ].freeze
+
+    def resources
+      RESOURCES
+    end
+
+    def include?(resource)
+      RESOURCES.include?(resource.to_s)
+    end
+
+    def model_for(resource)
+      resource.to_s.classify.constantize
+    end
+
+    def writable_attributes(resource)
+      controller_for(resource).permitted_attributes.map(&:to_s)
+    end
+
+    def controller_for(resource)
+      "Api::V1::#{resource.to_s.camelize}Controller".constantize
+    end
+  end
+end

--- a/app/services/mcp/server.rb
+++ b/app/services/mcp/server.rb
@@ -1,0 +1,22 @@
+module Mcp
+  # Builds the MCP server exposing the resource tools. `user` is the owner who
+  # authorized the connector; it's passed through as server context.
+  class Server
+    TOOLS = [
+      Tools::ListRecords,
+      Tools::GetRecord,
+      Tools::CreateRecord,
+      Tools::UpdateRecord
+    ].freeze
+
+    def self.build(user)
+      ::MCP::Server.new(
+        name: "meitheal",
+        title: "Meitheal Admin",
+        version: "1.0.0",
+        tools: TOOLS,
+        server_context: { user: user }
+      )
+    end
+  end
+end

--- a/app/services/mcp/tools/base.rb
+++ b/app/services/mcp/tools/base.rb
@@ -1,0 +1,31 @@
+module Mcp
+  module Tools
+    # Shared helpers for the resource tools. Concrete tools declare their own
+    # name/description/input_schema and implement `self.call`.
+    class Base < MCP::Tool
+      class << self
+        private
+
+        def registry
+          Mcp::ResourceRegistry
+        end
+
+        def json_response(data)
+          MCP::Tool::Response.new([ { type: "text", text: JSON.pretty_generate(data) } ])
+        end
+
+        def error(message)
+          MCP::Tool::Response.new([ { type: "text", text: message } ], error: true)
+        end
+
+        def serialize(record)
+          Api::RecordSerializer.call(record)
+        end
+
+        def writable(resource, attributes)
+          (attributes || {}).stringify_keys.slice(*registry.writable_attributes(resource))
+        end
+      end
+    end
+  end
+end

--- a/app/services/mcp/tools/create_record.rb
+++ b/app/services/mcp/tools/create_record.rb
@@ -1,0 +1,33 @@
+module Mcp
+  module Tools
+    class CreateRecord < Base
+      tool_name "create_record"
+      description "Create a record of a resource. `attributes` is an object of field values; " \
+                  "unknown or non-writable fields are ignored. Rich-text fields (e.g. answer, " \
+                  "content, body) accept HTML. Call get_record or list_records first to learn a " \
+                  "resource's fields. Returns the created record or validation errors."
+      input_schema(
+        properties: {
+          resource: {
+            type: "string",
+            enum: Mcp::ResourceRegistry::RESOURCES,
+            description: "Which resource to create"
+          },
+          attributes: { type: "object", description: "Field values for the new record" }
+        },
+        required: [ "resource", "attributes" ]
+      )
+
+      def self.call(resource:, attributes:, server_context:)
+        return error("Unknown resource: #{resource}") unless registry.include?(resource)
+
+        record = registry.model_for(resource).new(writable(resource, attributes))
+        if record.save
+          json_response(serialize(record))
+        else
+          error(record.errors.full_messages.join(", "))
+        end
+      end
+    end
+  end
+end

--- a/app/services/mcp/tools/get_record.rb
+++ b/app/services/mcp/tools/get_record.rb
@@ -1,0 +1,28 @@
+module Mcp
+  module Tools
+    class GetRecord < Base
+      tool_name "get_record"
+      description "Fetch a single record of a resource by id."
+      input_schema(
+        properties: {
+          resource: {
+            type: "string",
+            enum: Mcp::ResourceRegistry::RESOURCES,
+            description: "Which resource the record belongs to"
+          },
+          id: { type: "integer", description: "Record id" }
+        },
+        required: [ "resource", "id" ]
+      )
+
+      def self.call(resource:, id:, server_context:)
+        return error("Unknown resource: #{resource}") unless registry.include?(resource)
+
+        record = registry.model_for(resource).find_by(id: id)
+        return error("#{resource} ##{id} not found") unless record
+
+        json_response(serialize(record))
+      end
+    end
+  end
+end

--- a/app/services/mcp/tools/list_records.rb
+++ b/app/services/mcp/tools/list_records.rb
@@ -1,0 +1,26 @@
+module Mcp
+  module Tools
+    class ListRecords < Base
+      tool_name "list_records"
+      description "List all records of a resource. Returns each record's fields as JSON, " \
+                  "including rich-text fields rendered as HTML."
+      input_schema(
+        properties: {
+          resource: {
+            type: "string",
+            enum: Mcp::ResourceRegistry::RESOURCES,
+            description: "Which resource collection to list"
+          }
+        },
+        required: [ "resource" ]
+      )
+
+      def self.call(resource:, server_context:)
+        return error("Unknown resource: #{resource}") unless registry.include?(resource)
+
+        records = registry.model_for(resource).all.map { |record| serialize(record) }
+        json_response(records)
+      end
+    end
+  end
+end

--- a/app/services/mcp/tools/update_record.rb
+++ b/app/services/mcp/tools/update_record.rb
@@ -1,0 +1,35 @@
+module Mcp
+  module Tools
+    class UpdateRecord < Base
+      tool_name "update_record"
+      description "Update an existing record. `attributes` is an object of field values to change; " \
+                  "unknown or non-writable fields are ignored. Rich-text fields accept HTML. " \
+                  "Returns the updated record or validation errors."
+      input_schema(
+        properties: {
+          resource: {
+            type: "string",
+            enum: Mcp::ResourceRegistry::RESOURCES,
+            description: "Which resource the record belongs to"
+          },
+          id: { type: "integer", description: "Record id" },
+          attributes: { type: "object", description: "Field values to change" }
+        },
+        required: [ "resource", "id", "attributes" ]
+      )
+
+      def self.call(resource:, id:, attributes:, server_context:)
+        return error("Unknown resource: #{resource}") unless registry.include?(resource)
+
+        record = registry.model_for(resource).find_by(id: id)
+        return error("#{resource} ##{id} not found") unless record
+
+        if record.update(writable(resource, attributes))
+          json_response(serialize(record))
+        else
+          error(record.errors.full_messages.join(", "))
+        end
+      end
+    end
+  end
+end

--- a/config/initializers/doorkeeper.rb
+++ b/config/initializers/doorkeeper.rb
@@ -1,0 +1,562 @@
+# frozen_string_literal: true
+
+Doorkeeper.configure do
+  # Change the ORM that doorkeeper will use (requires ORM extensions installed).
+  # Check the list of supported ORMs here: https://github.com/doorkeeper-gem/doorkeeper#orms
+  orm :active_record
+
+  # Enable support for multiple database configurations with read replicas.
+  # When enabled, Doorkeeper will wrap database write operations to ensure they
+  # use the primary (writable) database when automatic role switching is enabled.
+  #
+  # For ActiveRecord (Rails 6.1+), this uses `ActiveRecord::Base.connected_to(role: :writing)`.
+  # Other ORM extensions can implement their own primary database targeting logic.
+  #
+  # enable_multiple_database_roles
+  #
+  # This prevents `ActiveRecord::ReadOnlyError` when using read replicas with Rails
+  # automatic role switching. Enable this if your application uses multiple databases
+  # with automatic role switching for read replicas.
+  #
+  # See: https://guides.rubyonrails.org/active_record_multiple_databases.html#activating-automatic-role-switching
+
+  # Resolve the resource owner from our signed session cookie. Only an owner may
+  # authorize a connector — anyone else is sent to sign in.
+  resource_owner_authenticator do
+    session_record = Session.find_by(id: cookies.signed[:session_id]) if cookies.signed[:session_id]
+    owner = session_record&.user if session_record&.user&.owner?
+    if owner
+      owner
+    else
+      session[:return_to_after_authenticating] = request.fullpath
+      redirect_to(new_session_path)
+      nil
+    end
+  end
+
+  # --- Settings for the claude.ai MCP connector (OAuth 2.1 + PKCE) ---
+  # Claude registers a public client and always sends an S256 PKCE challenge.
+  grant_flows %w[authorization_code]
+  force_pkce
+  pkce_code_challenge_methods %w[S256]
+
+  default_scopes "mcp:access"
+  enforce_configured_scopes
+
+  access_token_expires_in 2.hours
+  use_refresh_token
+
+  # If you didn't skip applications controller from Doorkeeper routes in your application routes.rb
+  # file then you need to declare this block in order to restrict access to the web interface for
+  # adding oauth authorized applications. In other case it will return 403 Forbidden response
+  # every time somebody will try to access the admin web interface.
+  #
+  # admin_authenticator do
+  #   # Put your admin authentication logic here.
+  #   # Example implementation:
+  #
+  #   if current_user
+  #     head :forbidden unless current_user.admin?
+  #   else
+  #     redirect_to sign_in_url
+  #   end
+  # end
+
+  # You can use your own model classes if you need to extend (or even override) default
+  # Doorkeeper models such as `Application`, `AccessToken` and `AccessGrant.
+  #
+  # By default Doorkeeper ActiveRecord ORM uses its own classes:
+  #
+  # access_token_class "Doorkeeper::AccessToken"
+  # access_grant_class "Doorkeeper::AccessGrant"
+  # application_class "Doorkeeper::Application"
+  #
+  # Don't forget to include Doorkeeper ORM mixins into your custom models:
+  #
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken - for access token
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessGrant - for access grant
+  #   *  ::Doorkeeper::Orm::ActiveRecord::Mixins::Application - for application (OAuth2 clients)
+  #
+  # For example:
+  #
+  # access_token_class "MyAccessToken"
+  #
+  # class MyAccessToken < ApplicationRecord
+  #   include ::Doorkeeper::Orm::ActiveRecord::Mixins::AccessToken
+  #
+  #   self.table_name = "hey_i_wanna_my_name"
+  #
+  #   def destroy_me!
+  #     destroy
+  #   end
+  # end
+
+  # Enables polymorphic Resource Owner association for Access Tokens and Access Grants.
+  # By default this option is disabled.
+  #
+  # Make sure you properly setup you database and have all the required columns (run
+  # `bundle exec rails generate doorkeeper:enable_polymorphic_resource_owner` and execute Rails
+  # migrations).
+  #
+  # If this option enabled, Doorkeeper will store not only Resource Owner primary key
+  # value, but also it's type (class name). See "Polymorphic Associations" section of
+  # Rails guides: https://guides.rubyonrails.org/association_basics.html#polymorphic-associations
+  #
+  # [NOTE] If you apply this option on already existing project don't forget to manually
+  # update `resource_owner_type` column in the database and fix migration template as it will
+  # set NOT NULL constraint for Access Grants table.
+  #
+  # use_polymorphic_resource_owner
+
+  # If you are planning to use Doorkeeper in Rails 5 API-only application, then you might
+  # want to use API mode that will skip all the views management and change the way how
+  # Doorkeeper responds to a requests.
+  #
+  # api_only
+
+  # Enforce token request content type to application/x-www-form-urlencoded.
+  # It is not enabled by default to not break prior versions of the gem.
+  #
+  # enforce_content_type
+
+  # Authorization Code expiration time (default: 10 minutes).
+  #
+  # authorization_code_expires_in 10.minutes
+
+  # Access token expiration time (default: 2 hours).
+  # If you set this to `nil` Doorkeeper will not expire the token and omit expires_in in response.
+  # It is RECOMMENDED to set expiration time explicitly.
+  # Prefer access_token_expires_in 100.years or similar,
+  # which would be functionally equivalent and avoid the risk of unexpected behavior by callers.
+  #
+  # access_token_expires_in 2.hours
+
+  # Assign custom TTL for access tokens. Will be used instead of access_token_expires_in
+  # option if defined. In case the block returns `nil` value Doorkeeper fallbacks to
+  # +access_token_expires_in+ configuration option value. If you really need to issue a
+  # non-expiring access token (which is not recommended) then you need to return
+  # Float::INFINITY from this block.
+  #
+  # `context` has the following properties available:
+  #
+  #   * `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  #   * `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  #   * `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #   * `resource_owner` - authorized resource owner instance (if present)
+  #
+  # custom_access_token_expires_in do |context|
+  #   context.client.additional_settings.implicit_oauth_expiration
+  # end
+
+  # Use a custom class for generating the access token.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-access-token-generator
+  #
+  # access_token_generator '::Doorkeeper::JWT'
+
+  # The controller +Doorkeeper::ApplicationController+ inherits from.
+  # Defaults to +ActionController::Base+ unless +api_only+ is set, which changes the default to
+  # +ActionController::API+. The return value of this option must be a stringified class name.
+  # See https://doorkeeper.gitbook.io/guides/configuration/other-configurations#custom-controllers
+  #
+  # base_controller 'ApplicationController'
+
+  # Reuse access token for the same resource owner within an application (disabled by default).
+  #
+  # This option protects your application from creating new tokens before old **valid** one becomes
+  # expired so your database doesn't bloat. Keep in mind that when this option is enabled Doorkeeper
+  # doesn't update existing token expiration time, it will create a new token instead if no active matching
+  # token found for the application, resources owner and/or set of scopes.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/383
+  #
+  # You can not enable this option together with +hash_token_secrets+.
+  #
+  # reuse_access_token
+
+  # In case you enabled `reuse_access_token` option Doorkeeper will try to find matching
+  # token using `matching_token_for` Access Token API that searches for valid records
+  # in batches in order not to pollute the memory with all the database records. By default
+  # Doorkeeper uses batch size of 10 000 records. You can increase or decrease this value
+  # depending on your needs and server capabilities.
+  #
+  # token_lookup_batch_size 10_000
+
+  # Set a limit for token_reuse if using reuse_access_token option
+  #
+  # This option limits token_reusability to some extent.
+  # If not set then access_token will be reused unless it expires.
+  # Rationale: https://github.com/doorkeeper-gem/doorkeeper/issues/1189
+  #
+  # This option should be a percentage(i.e. (0,100])
+  #
+  # token_reuse_limit 100
+
+  # Only allow one valid access token obtained via client credentials
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # When enabling this option, make sure that you do not expect multiple processes
+  # using the same credentials at the same time (e.g. web servers spanning
+  # multiple machines and/or processes).
+  #
+  # revoke_previous_client_credentials_token
+
+  # Only allow one valid access token obtained via authorization code
+  # per client. If a new access token is obtained before the old one
+  # expired, the old one gets revoked (disabled by default)
+  #
+  # revoke_previous_authorization_code_token
+
+  # Require non-confidential clients to use PKCE when using an authorization code
+  # to obtain an access_token (disabled by default)
+  #
+  # force_pkce
+
+  # Hash access and refresh tokens before persisting them.
+  # This will disable the possibility to use +reuse_access_token+
+  # since plain values can no longer be retrieved.
+  #
+  # Note: If you are already a user of doorkeeper and have existing tokens
+  # in your installation, they will be invalid without adding 'fallback: :plain'.
+  #
+  # hash_token_secrets
+  # By default, token secrets will be hashed using the
+  # +Doorkeeper::Hashing::SHA256+ strategy.
+  #
+  # If you wish to use another hashing implementation, you can override
+  # this strategy as follows:
+  #
+  # hash_token_secrets using: '::Doorkeeper::Hashing::MyCustomHashImpl'
+  #
+  # Keep in mind that changing the hashing function will invalidate all existing
+  # secrets, if there are any.
+
+  # Hash application secrets before persisting them.
+  #
+  # hash_application_secrets
+  #
+  # By default, applications will be hashed
+  # with the +Doorkeeper::SecretStoring::SHA256+ strategy.
+  #
+  # If you wish to use bcrypt for application secret hashing, uncomment
+  # this line instead:
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt'
+
+  # When the above option is enabled, and a hashed token or secret is not found,
+  # you can allow to fall back to another strategy. For users upgrading
+  # doorkeeper and wishing to enable hashing, you will probably want to enable
+  # the fallback to plain tokens.
+  #
+  # This will ensure that old access tokens and secrets
+  # will remain valid even if the hashing above is enabled.
+  #
+  # This can be done by adding 'fallback: plain', e.g. :
+  #
+  # hash_application_secrets using: '::Doorkeeper::SecretStoring::BCrypt', fallback: :plain
+
+  # Issue access tokens with refresh token (disabled by default), you may also
+  # pass a block which accepts `context` to customize when to give a refresh
+  # token or not. Similar to +custom_access_token_expires_in+, `context` has
+  # the following properties:
+  #
+  # `client` - the OAuth client application (see Doorkeeper::OAuth::Client)
+  # `grant_type` - the grant type of the request (see Doorkeeper::OAuth)
+  # `scopes` - the requested scopes (see Doorkeeper::OAuth::Scopes)
+  #
+  # use_refresh_token
+
+  # Provide support for an owner to be assigned to each registered application (disabled by default)
+  # Optional parameter confirmation: true (default: false) if you want to enforce ownership of
+  # a registered application
+  # NOTE: you must also run the rails g doorkeeper:application_owner generator
+  # to provide the necessary support
+  #
+  # enable_application_owner confirmation: false
+
+  # Define access token scopes for your provider
+  # For more information go to
+  # https://doorkeeper.gitbook.io/guides/ruby-on-rails/scopes
+  #
+  # default_scopes  :public
+  # optional_scopes :write, :update
+
+  # Allows to restrict only certain scopes for grant_type.
+  # By default, all the scopes will be available for all the grant types.
+  #
+  # Keys to this hash should be the name of grant_type and
+  # values should be the array of scopes for that grant type.
+  # Note: scopes should be from configured_scopes (i.e. default or optional)
+  #
+  # scopes_by_grant_type password: [:write], client_credentials: [:update]
+
+  # Forbids creating/updating applications with arbitrary scopes that are
+  # not in configuration, i.e. +default_scopes+ or +optional_scopes+.
+  # (disabled by default)
+  #
+  # enforce_configured_scopes
+
+  # Change the way client credentials are retrieved from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:client_id` and `:client_secret` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # client_credentials :from_basic, :from_params
+
+  # Change the way access token is authenticated from the request object.
+  # By default it retrieves first from the `HTTP_AUTHORIZATION` header, then
+  # falls back to the `:access_token` or `:bearer_token` params from the `params` object.
+  # Check out https://github.com/doorkeeper-gem/doorkeeper/wiki/Changing-how-clients-are-authenticated
+  # for more information on customization
+  #
+  # access_token_methods :from_bearer_authorization, :from_access_token_param, :from_bearer_param
+
+  # Forces the usage of the HTTPS protocol in non-native redirect uris (enabled
+  # by default in non-development environments). OAuth2 delegates security in
+  # communication to the HTTPS protocol so it is wise to keep this enabled.
+  #
+  # Callable objects such as proc, lambda, block or any object that responds to
+  # #call can be used in order to allow conditional checks (to allow non-SSL
+  # redirects to localhost for example).
+  #
+  # force_ssl_in_redirect_uri !Rails.env.development?
+  #
+  # force_ssl_in_redirect_uri { |uri| uri.host != 'localhost' }
+
+  # Specify what redirect URI's you want to block during Application creation.
+  # Any redirect URI is allowed by default.
+  #
+  # You can use this option in order to forbid URI's with 'javascript' scheme
+  # for example.
+  #
+  # forbid_redirect_uri { |uri| uri.scheme.to_s.downcase == 'javascript' }
+
+  # Allows to set blank redirect URIs for Applications in case Doorkeeper configured
+  # to use URI-less OAuth grant flows like Client Credentials or Resource Owner
+  # Password Credentials. The option is on by default and checks configured grant
+  # types, but you **need** to manually drop `NOT NULL` constraint from `redirect_uri`
+  # column for `oauth_applications` database table.
+  #
+  # You can completely disable this feature with:
+  #
+  # allow_blank_redirect_uri false
+  #
+  # Or you can define your custom check:
+  #
+  # allow_blank_redirect_uri do |grant_flows, client|
+  #   client.superapp?
+  # end
+
+  # Specify how authorization errors should be handled.
+  # By default, doorkeeper renders json errors when access token
+  # is invalid, expired, revoked or has invalid scopes.
+  #
+  # If you want to render error response yourself (i.e. rescue exceptions),
+  # set +handle_auth_errors+ to `:raise` and rescue Doorkeeper::Errors::InvalidToken
+  # or following specific errors:
+  #
+  #   Doorkeeper::Errors::TokenForbidden, Doorkeeper::Errors::TokenExpired,
+  #   Doorkeeper::Errors::TokenRevoked, Doorkeeper::Errors::TokenUnknown
+  #
+  # handle_auth_errors :raise
+  #
+  # If you want to redirect back to the client application in accordance with
+  # https://datatracker.ietf.org/doc/html/rfc6749#section-4.1.2.1, you can set
+  # +handle_auth_errors+ to :redirect
+  #
+  # handle_auth_errors :redirect
+
+  # Customize token introspection response.
+  # Allows to add your own fields to default one that are required by the OAuth spec
+  # for the introspection response. It could be `sub`, `aud` and so on.
+  # This configuration option can be a proc, lambda or any Ruby object responds
+  # to `.call` method and result of it's invocation must be a Hash.
+  #
+  # custom_introspection_response do |token, context|
+  #   {
+  #     "sub": "Z5O3upPC88QrAjx00dis",
+  #     "aud": "https://protected.example.net/resource",
+  #     "username": User.find(token.resource_owner_id).username
+  #   }
+  # end
+  #
+  # or
+  #
+  # custom_introspection_response CustomIntrospectionResponder
+
+  # Specify what grant flows are enabled in array of Strings. The valid
+  # strings and the flows they enable are:
+  #
+  # "authorization_code" => Authorization Code Grant Flow
+  # "implicit"           => Implicit Grant Flow
+  # "password"           => Resource Owner Password Credentials Grant Flow
+  # "client_credentials" => Client Credentials Grant Flow
+  #
+  # If not specified, Doorkeeper enables authorization_code and
+  # client_credentials.
+  #
+  # implicit and password grant flows have risks that you should understand
+  # before enabling:
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.2
+  #   https://datatracker.ietf.org/doc/html/rfc6819#section-4.4.3
+  #
+  # grant_flows %w[authorization_code client_credentials]
+
+  # Allows to customize OAuth grant flows that +each+ application support.
+  # You can configure a custom block (or use a class respond to `#call`) that must
+  # return `true` in case Application instance supports requested OAuth grant flow
+  # during the authorization request to the server. This configuration +doesn't+
+  # set flows per application, it only allows to check if application supports
+  # specific grant flow.
+  #
+  # For example you can add an additional database column to `oauth_applications` table,
+  # say `t.array :grant_flows, default: []`, and store allowed grant flows that can
+  # be used with this application there. Then when authorization requested Doorkeeper
+  # will call this block to check if specific Application (passed with client_id and/or
+  # client_secret) is allowed to perform the request for the specific grant type
+  # (authorization, password, client_credentials, etc).
+  #
+  # Example of the block:
+  #
+  #   ->(flow, client) { client.grant_flows.include?(flow) }
+  #
+  # In case this option invocation result is `false`, Doorkeeper server returns
+  # :unauthorized_client error and stops the request.
+  #
+  # @param allow_grant_flow_for_client [Proc] Block or any object respond to #call
+  # @return [Boolean] `true` if allow or `false` if forbid the request
+  #
+  # allow_grant_flow_for_client do |grant_flow, client|
+  #   # `grant_flows` is an Array column with grant
+  #   # flows that application supports
+  #
+  #   client.grant_flows.include?(grant_flow)
+  # end
+
+  # If you need arbitrary Resource Owner-Client authorization you can enable this option
+  # and implement the check your need. Config option must respond to #call and return
+  # true in case resource owner authorized for the specific application or false in other
+  # cases.
+  #
+  # By default all Resource Owners are authorized to any Client (application).
+  #
+  # authorize_resource_owner_for_client do |client, resource_owner|
+  #   resource_owner.admin? || client.owners_allowlist.include?(resource_owner)
+  # end
+
+  # Allows additional data fields to be sent while granting access to an application,
+  # and for this additional data to be included in subsequently generated access tokens.
+  # The 'authorizations/new' page will need to be overridden to include this additional data
+  # in the request params when granting access. The access grant and access token models
+  # will both need to respond to these additional data fields, and have a database column
+  # to store them in.
+  #
+  # Example:
+  # You have a multi-tenanted platform and want to be able to grant access to a specific
+  # tenant, rather than all the tenants a user has access to. You can use this config
+  # option to specify that a ':tenant_id' will be passed when authorizing. This tenant_id
+  # will be included in the access tokens. When a request is made with one of these access
+  # tokens, you can check that the requested data belongs to the specified tenant.
+  #
+  # Default value is an empty Array: []
+  # custom_access_token_attributes [:tenant_id]
+
+  # Hook into the strategies' request & response life-cycle in case your
+  # application needs advanced customization or logging:
+  #
+  # before_successful_strategy_response do |request|
+  #   puts "BEFORE HOOK FIRED! #{request}"
+  # end
+  #
+  # after_successful_strategy_response do |request, response|
+  #   puts "AFTER HOOK FIRED! #{request}, #{response}"
+  # end
+
+  # Hook into Authorization flow in order to implement Single Sign Out
+  # or add any other functionality. Inside the block you have an access
+  # to `controller` (authorizations controller instance) and `context`
+  # (Doorkeeper::OAuth::Hooks::Context instance) which provides pre auth
+  # or auth objects with issued token based on hook type (before or after).
+  #
+  # before_successful_authorization do |controller, context|
+  #   Rails.logger.info(controller.request.params.inspect)
+  #
+  #   Rails.logger.info(context.pre_auth.inspect)
+  # end
+  #
+  # after_successful_authorization do |controller, context|
+  #   controller.session[:logout_urls] <<
+  #     Doorkeeper::Application
+  #       .find_by(controller.request.params.slice(:redirect_uri))
+  #       .logout_uri
+  #
+  #   Rails.logger.info(context.auth.inspect)
+  #   Rails.logger.info(context.issued_token)
+  # end
+
+  # Under some circumstances you might want to have applications auto-approved,
+  # so that the user skips the authorization step.
+  # For example if dealing with a trusted application.
+  #
+  # skip_authorization do |resource_owner, client|
+  #   client.superapp? or resource_owner.admin?
+  # end
+
+  # Configure custom constraints for the Token Introspection request.
+  # By default this configuration option allows to introspect a token by another
+  # token of the same application, OR to introspect the token that belongs to
+  # authorized client (from authenticated client) OR when token doesn't
+  # belong to any client (public token). Otherwise requester has no access to the
+  # introspection and it will return response as stated in the RFC.
+  #
+  # Block arguments:
+  #
+  # @param token [Doorkeeper::AccessToken]
+  #   token to be introspected
+  #
+  # @param authorized_client [Doorkeeper::Application]
+  #   authorized client (if request is authorized using Basic auth with
+  #   Client Credentials for example)
+  #
+  # @param authorized_token [Doorkeeper::AccessToken]
+  #   Bearer token used to authorize the request
+  #
+  # In case the block returns `nil` or `false` introspection responses with 401 status code
+  # when using authorized token to introspect, or you'll get 200 with { "active": false } body
+  # when using authorized client to introspect as stated in the
+  # RFC 7662 section 2.2. Introspection Response.
+  #
+  # Using with caution:
+  # Keep in mind that these three parameters pass to block can be nil as following case:
+  #  `authorized_client` is nil if and only if `authorized_token` is present, and vice versa.
+  #  `token` will be nil if and only if `authorized_token` is present.
+  # So remember to use `&` or check if it is present before calling method on
+  # them to make sure you doesn't get NoMethodError exception.
+  #
+  # You can define your custom check:
+  #
+  # allow_token_introspection do |token, authorized_client, authorized_token|
+  #   if authorized_token
+  #     # customize: require `introspection` scope
+  #     authorized_token.application == token&.application ||
+  #       authorized_token.scopes.include?("introspection")
+  #   elsif token.application
+  #     # `protected_resource` is a new database boolean column, for example
+  #     authorized_client == token.application || authorized_client.protected_resource?
+  #   else
+  #     # public token (when token.application is nil, token doesn't belong to any application)
+  #     true
+  #   end
+  # end
+  #
+  # Or you can completely disable any token introspection:
+  #
+  # allow_token_introspection false
+  #
+  # If you need to block the request at all, then configure your routes.rb or web-server
+  # like nginx to forbid the request.
+
+  # WWW-Authenticate Realm (default: "Doorkeeper").
+  #
+  # realm "Doorkeeper"
+end

--- a/config/locales/doorkeeper.en.yml
+++ b/config/locales/doorkeeper.en.yml
@@ -1,0 +1,155 @@
+en:
+  activerecord:
+    attributes:
+      doorkeeper/application:
+        name: 'Name'
+        redirect_uri: 'Redirect URI'
+    errors:
+      models:
+        doorkeeper/application:
+          attributes:
+            redirect_uri:
+              fragment_present: 'cannot contain a fragment.'
+              invalid_uri: 'must be a valid URI.'
+              unspecified_scheme: 'must specify a scheme.'
+              relative_uri: 'must be an absolute URI.'
+              secured_uri: 'must be an HTTPS/SSL URI.'
+              forbidden_uri: 'is forbidden by the server.'
+            scopes:
+              not_match_configured: "doesn't match those configured on the server."
+
+  doorkeeper:
+    applications:
+      confirmations:
+        destroy: 'Are you sure?'
+      buttons:
+        edit: 'Edit'
+        destroy: 'Destroy'
+        submit: 'Submit'
+        cancel: 'Cancel'
+        authorize: 'Authorize'
+      form:
+        error: 'Whoops! Check your form for possible errors'
+      help:
+        confidential: 'Application will be used where the client secret can be kept confidential. Native mobile apps and Single Page Apps are considered non-confidential.'
+        redirect_uri: 'Use one line per URI'
+        blank_redirect_uri: "Leave it blank if you configured your provider to use Client Credentials, Resource Owner Password Credentials or any other grant type that doesn't require a redirect URI."
+        scopes: 'Separate scopes with spaces. Leave blank to use the default scopes.'
+      edit:
+        title: 'Edit application'
+      index:
+        title: 'Your applications'
+        new: 'New Application'
+        name: 'Name'
+        callback_url: 'Callback URL'
+        confidential: 'Confidential?'
+        actions: 'Actions'
+        confidentiality:
+          'yes': 'Yes'
+          'no': 'No'
+      new:
+        title: 'New Application'
+      show:
+        title: 'Application: %{name}'
+        application_id: 'UID:'
+        secret: 'Secret:'
+        secret_hashed: 'Secret hashed'
+        scopes: 'Scopes:'
+        confidential: 'Confidential:'
+        callback_urls: 'Callback URLs:'
+        actions: 'Actions'
+        not_defined: 'Not defined'
+
+    authorizations:
+      buttons:
+        authorize: 'Authorize'
+        deny: 'Deny'
+      error:
+        title: 'An error has occurred'
+      new:
+        title: 'Authorization required'
+        prompt: 'Authorize %{client_name} to use your account?'
+        able_to: 'This application will be able to:'
+      show:
+        title: 'Authorization code:'
+      form_post:
+        title: 'Submit this form'
+
+    authorized_applications:
+      confirmations:
+        revoke: 'Are you sure?'
+      buttons:
+        revoke: 'Revoke'
+      index:
+        title: 'Your authorized applications'
+        application: 'Application'
+        created_at: 'Created At'
+        date_format: '%Y-%m-%d %H:%M:%S'
+
+    pre_authorization:
+      status: 'Pre-authorization'
+
+    errors:
+      messages:
+        # Common error messages
+        invalid_request:
+          unknown: 'The request is missing a required parameter, includes an unsupported parameter value, or is otherwise malformed.'
+          missing_param: 'Missing required parameter: %{value}.'
+          request_not_authorized: 'Request needs to be authorized. Required parameter for authorizing the request is missing or invalid.'
+          invalid_code_challenge: 'Code challenge is required.'
+        invalid_redirect_uri: "The requested redirect URI is malformed or doesn't match the client redirect URI."
+        unauthorized_client: 'The client is not authorized to perform this request using this method.'
+        access_denied: 'The resource owner or authorization server denied the request.'
+        invalid_scope: 'The requested scope is invalid, unknown, or malformed.'
+        invalid_code_challenge_method:
+          zero: 'The authorization server does not support PKCE as there are no accepted code_challenge_method values.'
+          one: 'The code_challenge_method must be %{challenge_methods}.'
+          other: 'The code_challenge_method must be one of %{challenge_methods}.'
+        server_error: 'The authorization server encountered an unexpected condition which prevented it from fulfilling the request.'
+        temporarily_unavailable: 'The authorization server is currently unable to handle the request due to a temporary overloading or maintenance of the server.'
+
+        # Configuration error messages
+        credential_flow_not_configured: 'Resource Owner Password Credentials flow failed due to Doorkeeper.configure.resource_owner_from_credentials being unconfigured.'
+        resource_owner_authenticator_not_configured: 'Resource Owner find failed due to Doorkeeper.configure.resource_owner_authenticator being unconfigured.'
+        admin_authenticator_not_configured: 'Access to admin panel is forbidden due to Doorkeeper.configure.admin_authenticator being unconfigured.'
+
+        # Access grant errors
+        unsupported_response_type: 'The authorization server does not support this response type.'
+        unsupported_response_mode: 'The authorization server does not support this response mode.'
+
+        # Access token errors
+        invalid_client: 'Client authentication failed due to unknown client, no client authentication included, or unsupported authentication method.'
+        invalid_grant: 'The provided authorization grant is invalid, expired, revoked, does not match the redirection URI used in the authorization request, or was issued to another client.'
+        unsupported_grant_type: 'The authorization grant type is not supported by the authorization server.'
+
+        invalid_token:
+          revoked: "The access token was revoked"
+          expired: "The access token expired"
+          unknown: "The access token is invalid"
+        revoke:
+          unauthorized: "You are not authorized to revoke this token"
+
+        forbidden_token:
+          missing_scope: 'Access to this resource requires scope "%{oauth_scopes}".'
+
+    flash:
+      applications:
+        create:
+          notice: 'Application created.'
+        destroy:
+          notice: 'Application deleted.'
+        update:
+          notice: 'Application updated.'
+      authorized_applications:
+        destroy:
+          notice: 'Application revoked.'
+
+    layouts:
+      admin:
+        title: 'Doorkeeper'
+        nav:
+          oauth2_provider: 'OAuth2 Provider'
+          applications: 'Applications'
+          home: 'Home'
+      application:
+        title: 'OAuth authorization required'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -2,6 +2,28 @@ Rails.application.routes.draw do
   mount MissionControl::Jobs::Engine, at: "/jobs"
   mount Litestream::Engine, at: "/litestream"
 
+  namespace :api do
+    namespace :v1 do
+      resources_only = { only: [ :index, :show, :create, :update ] }
+      resources :faqs, **resources_only
+      resources :pages, **resources_only
+      resources :posts, **resources_only
+      resources :events, **resources_only
+      resources :newsletters, **resources_only
+      resources :funding_opportunities, **resources_only
+      resources :spaces, **resources_only
+      resources :bookings, **resources_only
+      resources :memberships, **resources_only
+      resources :proposals, **resources_only
+      resources :payments, **resources_only
+      resources :tickets, **resources_only
+      resources :email_groups, **resources_only
+      resources :admin_todos, **resources_only
+      resources :profiles, **resources_only
+      resources :users, **resources_only
+    end
+  end
+
   resources :posts, param: :slug do
     member do
       patch :publish

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,15 @@
 Rails.application.routes.draw do
+  use_doorkeeper
+
+  # claude.ai MCP connector: OAuth 2.1 discovery, dynamic client registration,
+  # and the MCP endpoint itself. Kept above the catch-all `get ":slug"` route.
+  get ".well-known/oauth-authorization-server", to: "oauth/metadata#authorization_server"
+  get ".well-known/oauth-authorization-server/mcp", to: "oauth/metadata#authorization_server"
+  get ".well-known/oauth-protected-resource", to: "oauth/metadata#protected_resource", as: :oauth_protected_resource
+  get ".well-known/oauth-protected-resource/mcp", to: "oauth/metadata#protected_resource"
+  post "oauth/register", to: "oauth/registrations#create", as: :oauth_register
+  match "mcp", to: "mcp#invoke", via: %i[get post], as: :mcp
+
   mount MissionControl::Jobs::Engine, at: "/jobs"
   mount Litestream::Engine, at: "/litestream"
 

--- a/db/migrate/20260703165532_create_doorkeeper_tables.rb
+++ b/db/migrate/20260703165532_create_doorkeeper_tables.rb
@@ -1,0 +1,101 @@
+# frozen_string_literal: true
+
+class CreateDoorkeeperTables < ActiveRecord::Migration[8.1]
+  def change
+    create_table :oauth_applications do |t|
+      t.string  :name,    null: false
+      t.string  :uid,     null: false
+      # Nullable so Claude's dynamically-registered public clients (no secret) are valid.
+      t.string  :secret
+
+      # Remove `null: false` if you are planning to use grant flows
+      # that doesn't require redirect URI to be used during authorization
+      # like Client Credentials flow or Resource Owner Password.
+      t.text    :redirect_uri, null: false
+      t.string  :scopes,       null: false, default: ''
+      t.boolean :confidential, null: false, default: true
+      t.timestamps             null: false
+    end
+
+    add_index :oauth_applications, :uid, unique: true
+
+    create_table :oauth_access_grants do |t|
+      t.references :resource_owner,  null: false
+      t.references :application,     null: false
+      t.string   :token,             null: false
+      t.integer  :expires_in,        null: false
+      t.text     :redirect_uri,      null: false
+      t.string   :scopes,            null: false, default: ''
+      t.datetime :created_at,        null: false
+      t.datetime :revoked_at
+      # PKCE (RFC 7636) — required by Claude connectors (S256)
+      t.string   :code_challenge
+      t.string   :code_challenge_method
+    end
+
+    add_index :oauth_access_grants, :token, unique: true
+    add_foreign_key(
+      :oauth_access_grants,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    create_table :oauth_access_tokens do |t|
+      t.references :resource_owner, index: true
+
+      # Remove `null: false` if you are planning to use Password
+      # Credentials Grant flow that doesn't require an application.
+      t.references :application,    null: false
+
+      # If you use a custom token generator you may need to change this column
+      # from string to text, so that it accepts tokens larger than 255
+      # characters. More info on custom token generators in:
+      # https://github.com/doorkeeper-gem/doorkeeper/tree/v3.0.0.rc1#custom-access-token-generator
+      #
+      # t.text :token, null: false
+      t.string :token, null: false
+
+      t.string   :refresh_token
+      t.integer  :expires_in
+      t.string   :scopes
+      t.datetime :created_at, null: false
+      t.datetime :revoked_at
+
+      # The authorization server MAY issue a new refresh token, in which case
+      # *the client MUST discard the old refresh token* and replace it with the
+      # new refresh token. The authorization server MAY revoke the old
+      # refresh token after issuing a new refresh token to the client.
+      # @see https://datatracker.ietf.org/doc/html/rfc6749#section-6
+      #
+      # Doorkeeper implementation: if there is a `previous_refresh_token` column,
+      # refresh tokens will be revoked after a related access token is used.
+      # If there is no `previous_refresh_token` column, previous tokens are
+      # revoked as soon as a new access token is created.
+      #
+      # Comment out this line if you want refresh tokens to be instantly
+      # revoked after use.
+      t.string   :previous_refresh_token, null: false, default: ""
+    end
+
+    add_index :oauth_access_tokens, :token, unique: true
+
+    # See https://github.com/doorkeeper-gem/doorkeeper/issues/1592
+    if ActiveRecord::Base.connection.adapter_name == "SQLServer"
+      execute <<~SQL.squish
+        CREATE UNIQUE NONCLUSTERED INDEX index_oauth_access_tokens_on_refresh_token ON oauth_access_tokens(refresh_token)
+        WHERE refresh_token IS NOT NULL
+      SQL
+    else
+      add_index :oauth_access_tokens, :refresh_token, unique: true
+    end
+
+    add_foreign_key(
+      :oauth_access_tokens,
+      :oauth_applications,
+      column: :application_id
+    )
+
+    add_foreign_key :oauth_access_grants, :users, column: :resource_owner_id
+    add_foreign_key :oauth_access_tokens, :users, column: :resource_owner_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_06_06_131905) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_03_165532) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end
@@ -283,6 +283,50 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_06_131905) do
     t.string "subject", null: false
     t.datetime "updated_at", null: false
     t.index ["chat_id"], name: "index_newsletters_on_chat_id"
+  end
+
+  create_table "oauth_access_grants", force: :cascade do |t|
+    t.integer "application_id", null: false
+    t.string "code_challenge"
+    t.string "code_challenge_method"
+    t.datetime "created_at", null: false
+    t.integer "expires_in", null: false
+    t.text "redirect_uri", null: false
+    t.integer "resource_owner_id", null: false
+    t.datetime "revoked_at"
+    t.string "scopes", default: "", null: false
+    t.string "token", null: false
+    t.index ["application_id"], name: "index_oauth_access_grants_on_application_id"
+    t.index ["resource_owner_id"], name: "index_oauth_access_grants_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_grants_on_token", unique: true
+  end
+
+  create_table "oauth_access_tokens", force: :cascade do |t|
+    t.integer "application_id", null: false
+    t.datetime "created_at", null: false
+    t.integer "expires_in"
+    t.string "previous_refresh_token", default: "", null: false
+    t.string "refresh_token"
+    t.integer "resource_owner_id"
+    t.datetime "revoked_at"
+    t.string "scopes"
+    t.string "token", null: false
+    t.index ["application_id"], name: "index_oauth_access_tokens_on_application_id"
+    t.index ["refresh_token"], name: "index_oauth_access_tokens_on_refresh_token", unique: true
+    t.index ["resource_owner_id"], name: "index_oauth_access_tokens_on_resource_owner_id"
+    t.index ["token"], name: "index_oauth_access_tokens_on_token", unique: true
+  end
+
+  create_table "oauth_applications", force: :cascade do |t|
+    t.boolean "confidential", default: true, null: false
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.text "redirect_uri", null: false
+    t.string "scopes", default: "", null: false
+    t.string "secret"
+    t.string "uid", null: false
+    t.datetime "updated_at", null: false
+    t.index ["uid"], name: "index_oauth_applications_on_uid", unique: true
   end
 
   create_table "pages", force: :cascade do |t|
@@ -668,6 +712,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_06_06_131905) do
   add_foreign_key "messages", "models"
   add_foreign_key "messages", "tool_calls"
   add_foreign_key "newsletters", "chats"
+  add_foreign_key "oauth_access_grants", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_grants", "users", column: "resource_owner_id"
+  add_foreign_key "oauth_access_tokens", "oauth_applications", column: "application_id"
+  add_foreign_key "oauth_access_tokens", "users", column: "resource_owner_id"
   add_foreign_key "payments", "memberships"
   add_foreign_key "posts", "users"
   add_foreign_key "profiles", "users"

--- a/docs/MCP_CONNECTOR.md
+++ b/docs/MCP_CONNECTOR.md
@@ -1,0 +1,69 @@
+# claude.ai MCP Connector
+
+Lets you read and edit the site's main resources from **claude.ai on the web**
+(and Claude Desktop / Code) through a custom connector, using natural language.
+
+The connector is an MCP server backed by an OAuth 2.1 authorization server built
+into this app. Only an **owner** account can authorize it, and every action runs
+as that owner.
+
+## What it exposes
+
+Four tools over the same resources as the REST API (`faqs`, `pages`, `posts`,
+`events`, `newsletters`, `funding_opportunities`, `spaces`, `bookings`,
+`memberships`, `proposals`, `payments`, `tickets`, `email_groups`, `admin_todos`,
+`profiles`, `users`):
+
+- `list_records(resource)`
+- `get_record(resource, id)`
+- `create_record(resource, attributes)`
+- `update_record(resource, id, attributes)`
+
+Writable fields per resource come straight from the REST API controllers
+(`app/controllers/api/v1/*`), so the two surfaces never disagree. There is **no
+delete tool**. `users.role` is not writable and password digests are never
+returned. Rich-text fields (`answer`, `content`, `body`, `rich_description`)
+accept and return HTML.
+
+## Endpoints
+
+| Path | Purpose |
+|------|---------|
+| `POST /mcp` | The MCP endpoint (JSON-RPC, Streamable HTTP). Requires a Bearer token with the `mcp:access` scope. |
+| `/.well-known/oauth-authorization-server` | RFC 8414 metadata Claude reads to discover the OAuth server. |
+| `/.well-known/oauth-protected-resource` | RFC 9728 metadata linking `/mcp` to its authorization server. |
+| `POST /oauth/register` | RFC 7591 dynamic client registration (Claude self-registers a public client). |
+| `/oauth/authorize`, `/oauth/token` | Doorkeeper authorization + token endpoints (PKCE S256 required). |
+
+## Adding it on claude.ai
+
+1. Deploy this app (the connector must be reachable over the public internet —
+   Claude connects from Anthropic's cloud, not your browser).
+2. In claude.ai: **Settings → Connectors → Add custom connector**.
+3. Enter the MCP URL: `https://<your-host>/mcp`
+4. Leave OAuth Client ID/Secret blank — Claude registers itself automatically via
+   dynamic client registration.
+5. Click **Add**, then **Connect**. Claude sends you to this app's sign-in page;
+   log in as an **owner** and approve. Claude then completes the PKCE flow and the
+   tools become available.
+
+Claude Desktop / Code use the same URL; they perform the same OAuth flow with a
+loopback redirect.
+
+## Deploy notes
+
+- Run migrations on deploy — the connector needs the `oauth_*` tables
+  (`CreateDoorkeeperTables`).
+- Token lifetime is 2 hours with refresh tokens (see
+  `config/initializers/doorkeeper.rb`).
+- The discovery metadata is built from the request host/scheme, so the app must
+  see its real external host (it does behind Thruster/Kamal via forwarded headers).
+- To revoke access, delete the relevant `Doorkeeper::Application` (and its tokens)
+  in the console: `Doorkeeper::Application.find_by(name: "...").destroy`.
+
+## Relationship to the REST API
+
+The REST API (`/api/v1/*`, single bearer token) still exists and is the simplest
+way to drive the same resources from **Claude Code / scripts**. The MCP connector
+is specifically what makes claude.ai on the web work. Both share the resource
+definitions and `Api::RecordSerializer`.

--- a/test/integration/api/v1/resources_api_test.rb
+++ b/test/integration/api/v1/resources_api_test.rb
@@ -1,0 +1,135 @@
+require "test_helper"
+
+module Api
+  module V1
+    class ResourcesApiTest < ActionDispatch::IntegrationTest
+      TOKEN = ENV["API_TOKEN"]
+
+      def auth_headers(token = TOKEN)
+        { "Authorization" => "Bearer #{token}", "Content-Type" => "application/json" }
+      end
+
+      # --- Authentication ---------------------------------------------------
+
+      test "rejects requests with no token" do
+        get api_v1_faqs_url
+        assert_response :unauthorized
+      end
+
+      test "rejects requests with a wrong token" do
+        get api_v1_faqs_url, headers: auth_headers("nope")
+        assert_response :unauthorized
+      end
+
+      test "accepts requests with the correct token" do
+        get api_v1_faqs_url, headers: auth_headers
+        assert_response :success
+      end
+
+      # --- Read -------------------------------------------------------------
+
+      test "index returns all records including rich-text fields" do
+        get api_v1_faqs_url, headers: auth_headers
+        assert_response :success
+        body = response.parsed_body
+        assert_equal Faq.count, body.size
+        assert body.first.key?("answer"), "expected rich-text 'answer' key in serialized faq"
+      end
+
+      test "show returns a single record" do
+        faq = faqs(:one)
+        get api_v1_faq_url(faq), headers: auth_headers
+        assert_response :success
+        assert_equal faq.id, response.parsed_body["id"]
+      end
+
+      test "show returns 404 for a missing record" do
+        get api_v1_faq_url(id: 0), headers: auth_headers
+        assert_response :not_found
+      end
+
+      # --- Create / Update --------------------------------------------------
+
+      test "create persists a valid record" do
+        assert_difference -> { Faq.count }, 1 do
+          post api_v1_faqs_url,
+            params: { faq: { question: "How do I use the API?", answer: "<p>Send a token.</p>", active: true } }.to_json,
+            headers: auth_headers
+        end
+        assert_response :created
+        assert_equal "How do I use the API?", response.parsed_body["question"]
+      end
+
+      test "create returns 422 with errors for an invalid record" do
+        assert_no_difference -> { Faq.count } do
+          post api_v1_faqs_url,
+            params: { faq: { answer: "<p>no question</p>" } }.to_json,
+            headers: auth_headers
+        end
+        assert_response :unprocessable_entity
+        assert_includes response.parsed_body["errors"], "Question can't be blank"
+      end
+
+      test "create returns 400 when the body carries no resource params" do
+        post api_v1_faqs_url, params: {}.to_json, headers: auth_headers
+        assert_response :bad_request
+      end
+
+      test "update changes an existing record" do
+        faq = faqs(:one)
+        patch api_v1_faq_url(faq),
+          params: { faq: { question: "Updated question" } }.to_json,
+          headers: auth_headers
+        assert_response :success
+        assert_equal "Updated question", faq.reload.question
+      end
+
+      # --- Rich text round-trips as HTML ------------------------------------
+
+      test "rich-text content round-trips as HTML" do
+        post api_v1_pages_url,
+          params: { page: { title: "API Page", slug: "api-page", locale: "en",
+                            visibility: "draft", content: "<p>Hello world</p>" } }.to_json,
+          headers: auth_headers
+        assert_response :created
+        assert_includes response.parsed_body["content"], "Hello world"
+      end
+
+      test "flat (unwrapped) body persists rich-text fields" do
+        post api_v1_faqs_url,
+          params: { question: "Flat body?", answer: "<p>kept</p>", active: true }.to_json,
+          headers: auth_headers
+        assert_response :created
+        assert_includes response.parsed_body["answer"], "kept"
+        assert_equal "kept", Faq.find(response.parsed_body["id"]).answer.to_plain_text
+      end
+
+      # --- Users are guarded ------------------------------------------------
+
+      test "user role cannot be changed through the API and digest is not exposed" do
+        user = users(:editor)
+        patch api_v1_user_url(user),
+          params: { user: { approved: false, role: "owner" } }.to_json,
+          headers: auth_headers
+        assert_response :success
+        assert_equal "editor", user.reload.role, "role must not be assignable via the API"
+        assert_not user.approved?, "permitted attributes should still update"
+        assert_not response.parsed_body.key?("password_digest")
+      end
+
+      # --- Every resource is reachable --------------------------------------
+
+      RESOURCE_INDEX_PATHS = %w[
+        faqs pages posts events newsletters funding_opportunities spaces bookings
+        memberships proposals payments tickets email_groups admin_todos profiles users
+      ].freeze
+
+      test "every resource index responds successfully" do
+        RESOURCE_INDEX_PATHS.each do |resource|
+          get "/api/v1/#{resource}", headers: auth_headers
+          assert_response :success, "GET /api/v1/#{resource} expected 200 but got #{response.status}"
+        end
+      end
+    end
+  end
+end

--- a/test/integration/mcp_endpoint_test.rb
+++ b/test/integration/mcp_endpoint_test.rb
@@ -1,0 +1,98 @@
+require "test_helper"
+
+# Drives the MCP endpoint the way Claude's connector does: JSON-RPC over an
+# access-token-protected POST.
+class McpEndpointTest < ActionDispatch::IntegrationTest
+  def setup
+    @oauth_app = Doorkeeper::Application.create!(
+      name: "Claude", redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+      scopes: "mcp:access", confidential: false
+    )
+    @token = Doorkeeper::AccessToken.create!(
+      application: @oauth_app, resource_owner_id: users(:owner).id,
+      scopes: "mcp:access", expires_in: 3600
+    ).token
+  end
+
+  def rpc(method, params = {}, token: @token)
+    headers = { "Content-Type" => "application/json" }
+    headers["Authorization"] = "Bearer #{token}" if token
+    post "/mcp", params: { jsonrpc: "2.0", id: 1, method: method, params: params }.to_json, headers: headers
+  end
+
+  # The text payload our tools return is itself JSON — parse it out.
+  def tool_json
+    JSON.parse(response.parsed_body.dig("result", "content", 0, "text"))
+  end
+
+  def tool_error?
+    response.parsed_body.dig("result", "isError")
+  end
+
+  test "rejects an unauthenticated call with a discovery pointer" do
+    post "/mcp", params: { jsonrpc: "2.0", id: 1, method: "tools/list" }.to_json,
+      headers: { "Content-Type" => "application/json" }
+    assert_response :unauthorized
+    assert_match %r{resource_metadata=".*oauth-protected-resource"}, response.headers["WWW-Authenticate"]
+  end
+
+  test "rejects a GET with 405" do
+    get "/mcp", headers: { "Authorization" => "Bearer #{@token}" }
+    assert_response :method_not_allowed
+  end
+
+  test "lists the resource tools" do
+    rpc("tools/list")
+    assert_response :success
+    names = response.parsed_body.dig("result", "tools").map { |t| t["name"] }
+    assert_equal %w[create_record get_record list_records update_record], names.sort
+  end
+
+  test "list_records returns serialized records" do
+    rpc("tools/call", { name: "list_records", arguments: { resource: "faqs" } })
+    assert_response :success
+    assert_equal Faq.count, tool_json.size
+  end
+
+  test "create_record persists a record with rich text" do
+    assert_difference -> { Faq.count }, 1 do
+      rpc("tools/call", { name: "create_record",
+        arguments: { resource: "faqs", attributes: { question: "Via MCP?", answer: "<p>yes</p>", active: true } } })
+    end
+    assert_response :success
+    assert_equal "Via MCP?", tool_json["question"]
+    assert_includes tool_json["answer"], "yes"
+  end
+
+  test "get_record then update_record round-trips" do
+    faq = faqs(:one)
+    rpc("tools/call", { name: "get_record", arguments: { resource: "faqs", id: faq.id } })
+    assert_equal faq.id, tool_json["id"]
+
+    rpc("tools/call", { name: "update_record",
+      arguments: { resource: "faqs", id: faq.id, attributes: { question: "Edited by MCP" } } })
+    assert_response :success
+    assert_equal "Edited by MCP", faq.reload.question
+  end
+
+  test "invalid attributes surface as a tool error" do
+    rpc("tools/call", { name: "create_record",
+      arguments: { resource: "faqs", attributes: { answer: "<p>no question</p>" } } })
+    assert tool_error?
+    assert_match "Question can't be blank", response.parsed_body.dig("result", "content", 0, "text")
+  end
+
+  test "an unknown resource is rejected" do
+    rpc("tools/call", { name: "list_records", arguments: { resource: "sessions" } })
+    assert tool_error?
+  end
+
+  test "user role cannot be set through the MCP tools" do
+    rpc("tools/call", { name: "create_record",
+      arguments: { resource: "users", attributes: { email_address: "mcp@example.com", password: "secret123", role: "owner" } } })
+    assert_response :success
+    created = User.find_by(email_address: "mcp@example.com")
+    assert_equal "viewer", created.role, "role must not be assignable via MCP"
+    assert_not tool_json.key?("password_digest"), "digest must never be serialized"
+  end
+end

--- a/test/integration/oauth_connector_test.rb
+++ b/test/integration/oauth_connector_test.rb
@@ -1,0 +1,85 @@
+require "test_helper"
+
+# Covers the OAuth 2.1 surface Claude's connector relies on: discovery metadata,
+# dynamic client registration, and the PKCE-protected token exchange.
+class OauthConnectorTest < ActionDispatch::IntegrationTest
+  test "authorization server metadata advertises the endpoints and S256 PKCE" do
+    get "/.well-known/oauth-authorization-server"
+    assert_response :success
+    body = response.parsed_body
+    assert_equal "http://www.example.com", body["issuer"]
+    assert_equal "http://www.example.com/oauth/authorize", body["authorization_endpoint"]
+    assert_equal "http://www.example.com/oauth/token", body["token_endpoint"]
+    assert_equal "http://www.example.com/oauth/register", body["registration_endpoint"]
+    assert_equal [ "S256" ], body["code_challenge_methods_supported"]
+    assert_includes body["scopes_supported"], "mcp:access"
+  end
+
+  test "protected resource metadata points at the MCP endpoint and its auth server" do
+    get "/.well-known/oauth-protected-resource"
+    assert_response :success
+    body = response.parsed_body
+    assert_equal "http://www.example.com/mcp", body["resource"]
+    assert_equal [ "http://www.example.com" ], body["authorization_servers"]
+  end
+
+  test "the /mcp path variant of the metadata is also served" do
+    get "/.well-known/oauth-authorization-server/mcp"
+    assert_response :success
+  end
+
+  test "dynamic client registration creates a public client" do
+    assert_difference -> { Doorkeeper::Application.count }, 1 do
+      post "/oauth/register", params: {
+        client_name: "Claude", redirect_uris: [ "https://claude.ai/api/mcp/auth_callback" ]
+      }.to_json, headers: { "Content-Type" => "application/json" }
+    end
+    assert_response :created
+    body = response.parsed_body
+    assert body["client_id"].present?
+    assert_equal "none", body["token_endpoint_auth_method"]
+
+    app = Doorkeeper::Application.find_by(uid: body["client_id"])
+    assert_not app.confidential?, "registered client must be public"
+  end
+
+  test "registration without a redirect uri is rejected" do
+    post "/oauth/register", params: { client_name: "Claude" }.to_json,
+      headers: { "Content-Type" => "application/json" }
+    assert_response :bad_request
+    assert_equal "invalid_client_metadata", response.parsed_body["error"]
+  end
+
+  test "token endpoint issues a token for a valid PKCE code and rejects a bad verifier" do
+    verifier = "a" * 64
+    challenge = Base64.urlsafe_encode64(Digest::SHA256.digest(verifier), padding: false)
+    app = Doorkeeper::Application.create!(
+      name: "Claude", redirect_uri: "https://claude.ai/api/mcp/auth_callback",
+      scopes: "mcp:access", confidential: false
+    )
+
+    grant = lambda do
+      Doorkeeper::AccessGrant.create!(
+        application: app, resource_owner_id: users(:owner).id,
+        redirect_uri: app.redirect_uri, expires_in: 600, scopes: "mcp:access",
+        code_challenge: challenge, code_challenge_method: "S256"
+      )
+    end
+
+    # Wrong verifier is refused.
+    post "/oauth/token", params: {
+      grant_type: "authorization_code", code: grant.call.token,
+      redirect_uri: app.redirect_uri, client_id: app.uid, code_verifier: "wrong"
+    }
+    assert_response :bad_request
+
+    # Correct verifier yields an access token scoped to mcp:access.
+    post "/oauth/token", params: {
+      grant_type: "authorization_code", code: grant.call.token,
+      redirect_uri: app.redirect_uri, client_id: app.uid, code_verifier: verifier
+    }
+    assert_response :success
+    assert response.parsed_body["access_token"].present?
+    assert_equal "mcp:access", response.parsed_body["scope"]
+  end
+end

--- a/test/test_helper.rb
+++ b/test/test_helper.rb
@@ -15,6 +15,9 @@ WebMock.disable_net_connect!(
 ENV["SUMUP_API_KEY"] ||= "test-api-key"
 ENV["SUMUP_MERCHANT_CODE"] ||= "TEST_MERCHANT"
 
+# Bearer token used by the JSON API in tests
+ENV["API_TOKEN"] ||= "test-api-token"
+
 module ActiveSupport
   class TestCase
     # Run tests in parallel with specified workers


### PR DESCRIPTION
Adds programmatic access to the site's main resources so they can be edited from Claude — a token-auth REST API for Claude Code, and an OAuth-backed MCP connector for claude.ai on the web.

## REST API (`bab8c55`)
- `GET/POST/PATCH /api/v1/*` (index/show/create/update — no destroy) over 16 resources: faqs, pages, posts, events, newsletters, funding_opportunities, spaces, bookings, memberships, proposals, payments, tickets, email_groups, admin_todos, profiles, users.
- Auth: single bearer token via Rails' native `authenticate_or_request_with_http_token` (`API_TOKEN`).
- Generic `ResourceController` + thin per-resource subclasses declaring writable attributes (mass-assignment safety). Rich text round-trips as HTML; flat or nested JSON both work. `users.role` unwritable, digests never returned.

## MCP connector + OAuth 2.1 (`959944d`)
claude.ai custom connectors can't take a static token, so the app is now its own OAuth 2.1 authorization server (Doorkeeper): forced S256 PKCE, owner-only consent, RFC 7591 dynamic client registration, RFC 8414/9728 discovery metadata.
- `POST /mcp`: JSON-RPC (official `mcp` gem) guarded by a Doorkeeper access token; 401 → `WWW-Authenticate` discovery pointer.
- Tools `list_records`/`get_record`/`create_record`/`update_record` sharing the REST controllers' writable-field definitions and `Api::RecordSerializer`, so the two surfaces can't drift.

## Testing
- New integration tests for the REST API, OAuth discovery/DCR/PKCE token exchange, and the MCP endpoint (auth, tools, guards). Full suite: 725 runs, 0 failures. Zeitwerk + RuboCop clean.

## Deploy notes
- Requires the Doorkeeper migration (`oauth_*` tables) to run on deploy.
- Set `API_TOKEN` for the REST API.
- claude.ai connector setup in `docs/MCP_CONNECTOR.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)