### PR TITLE
Fix crash when deleting a user who has posts or proposals (Sentry THENCF-J)

### DIFF
--- a/db/migrate/20260705071230_allow_null_user_on_posts_and_proposals.rb
+++ b/db/migrate/20260705071230_allow_null_user_on_posts_and_proposals.rb
@@ -1,0 +1,7 @@
+class AllowNullUserOnPostsAndProposals < ActiveRecord::Migration[8.1]
+  def change
+    # posts and proposals use dependent: :nullify so user_id must be nullable
+    change_column_null :posts, :user_id, true
+    change_column_null :proposals, :user_id, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_165532) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_05_071230) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end
@@ -370,7 +370,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_165532) do
     t.string "slug"
     t.string "title"
     t.datetime "updated_at", null: false
-    t.integer "user_id", null: false
+    t.integer "user_id"
     t.index ["slug"], name: "index_posts_on_slug", unique: true
     t.index ["user_id"], name: "index_posts_on_user_id"
   end
@@ -402,7 +402,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_165532) do
     t.datetime "submitted_at"
     t.string "title", null: false
     t.datetime "updated_at", null: false
-    t.integer "user_id", null: false
+    t.integer "user_id"
     t.index ["funding_opportunity_id"], name: "index_proposals_on_funding_opportunity_id"
     t.index ["user_id", "funding_opportunity_id"], name: "index_proposals_on_user_id_and_funding_opportunity_id", unique: true
     t.index ["user_id"], name: "index_proposals_on_user_id"

--- a/test/models/user_test.rb
+++ b/test/models/user_test.rb
@@ -59,4 +59,32 @@ class UserTest < ActiveSupport::TestCase
     assert_not editor.can_manage?
     assert_not viewer.can_manage?
   end
+
+  test "destroying a user nullifies their posts" do
+    user = User.create!(email_address: "nullify-posts@example.com", password: "password123")
+    post = Post.create!(user: user, title: "Orphan Post", slug: "orphan-post", post_type: 0)
+
+    assert_difference "Post.count", 0 do
+      user.destroy!
+    end
+
+    assert_nil post.reload.user_id
+  end
+
+  test "destroying a user nullifies their proposals" do
+    user = User.create!(email_address: "nullify-proposals@example.com", password: "password123")
+    opportunity = funding_opportunities(:arts_council_grant)
+    proposal = Proposal.create!(
+      user: user,
+      funding_opportunity: opportunity,
+      title: "Orphan Proposal",
+      status: :draft
+    )
+
+    assert_difference "Proposal.count", 0 do
+      user.destroy!
+    end
+
+    assert_nil proposal.reload.user_id
+  end
 end


### PR DESCRIPTION
## Root cause

`User` declares `has_many :posts, dependent: :nullify` and `has_many :proposals, dependent: :nullify`, meaning posts and proposals should be kept when their author is deleted (with `user_id` set to NULL).

However, both `posts.user_id` and `proposals.user_id` were created with `null: false` (NOT NULL) in the database. When Rails tried to nullify the column during user deletion it raised:

```
ActiveRecord::NotNullViolation: SQLite3::ConstraintException: NOT NULL constraint failed: posts.user_id
```

This error surfaced in production via a `rails runner` script that deleted a user — [Sentry THENCF-J](https://seo-cahill.sentry.io/issues/THENCF-J). The same constraint mismatch exists on `proposals.user_id`.

## Fix

Single migration — remove the NOT NULL constraint from both columns so the `dependent: :nullify` behaviour can work as intended:

```ruby
change_column_null :posts, :user_id, true
change_column_null :proposals, :user_id, true
```

## Tests

Two new model tests added:

- `destroying a user nullifies their posts` — previously raised `NotNullViolation`, now passes and asserts `post.user_id` is nil after destroy
- `destroying a user nullifies their proposals` — same for proposals

Full suite: 727 tests, 0 failures, 0 errors.

## Sentry

- Fixes [THENCF-J](https://seo-cahill.sentry.io/issues/THENCF-J)

---
_Generated by [Claude Code](https://claude.ai/code/session_016FFKczw5X7pwQD6KivcuZd)_