### PR TITLE
Handle blank email subjects in SyncZohoEmailsJob

### DIFF
--- a/app/jobs/sync_zoho_emails_job.rb
+++ b/app/jobs/sync_zoho_emails_job.rb
@@ -36,7 +36,7 @@ class SyncZohoEmailsJob < ApplicationJob
       zoho_message_id: message_id,
       zoho_folder_id: folder_id,
       from_address: email_data["fromAddress"],
-      subject: email_data["subject"],
+      subject: email_data["subject"].presence || "(No Subject)",
       summary: email_data["summary"],
       body: body,
       received_at: Time.at(email_data["receivedTime"].to_i / 1000)

--- a/test/jobs/sync_zoho_emails_job_test.rb
+++ b/test/jobs/sync_zoho_emails_job_test.rb
@@ -195,6 +195,26 @@ class SyncZohoEmailsJobTest < ActiveJob::TestCase
     assert_match "ImageDisplay", email.body
   end
 
+  test "uses '(No Subject)' fallback when email has blank subject" do
+    no_subject_email = {
+      "messageId" => "msg_003",
+      "fromAddress" => "sender@example.com",
+      "subject" => "",
+      "summary" => "Summary without subject",
+      "receivedTime" => (30.minutes.ago.to_f * 1000).to_i.to_s
+    }
+
+    zoho_emails = @zoho_emails + [ no_subject_email ]
+    @stub_zoho.define_singleton_method(:emails) { |folder_id:, limit:| zoho_emails }
+
+    assert_difference "CachedEmail.count", 3 do
+      assert_nothing_raised { SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho) }
+    end
+
+    email = CachedEmail.find_by(zoho_message_id: "msg_003")
+    assert_equal "(No Subject)", email.subject
+  end
+
   test "continues syncing when individual email content fetch fails" do
     call_count = 0
     @stub_zoho.define_singleton_method(:email) do |folder_id:, message_id:|


### PR DESCRIPTION
## Root cause

Some emails in Zoho arrive with a blank `subject` field (Zoho omits it rather than sending an empty string for truly subjectless messages). `CachedEmail` validates `subject: presence: true`, so `SyncZohoEmailsJob#sync_email` was raising `ActiveRecord::RecordInvalid` on every such email — 46 times since yesterday (Sentry issue [THENCF-W](https://seo-cahill.sentry.io/issues/THENCF-W)).

The job's `rescue` clause at `perform` level only catches `ZohoMailService::ApiError` and `Faraday::Error`, so `RecordInvalid` propagated unhandled and the entire sync run failed for every affected job execution.

## Fix

One-line change in `sync_email`: coerce a blank subject to `"(No Subject)"` using `presence ||` before passing it to `create!`. This is the standard email-client convention.

## Tests

Added a test covering the blank-subject case: a third email with `"subject" => ""` is synced, does not raise, and is stored as `"(No Subject)"`. Full suite: 726 tests, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01UP3Hof4bg1NscVkv5YA2tb)_