### PR TITLE
Fix SyncZohoEmailsJob crash on emails with blank subject

### DIFF
--- a/app/jobs/sync_zoho_emails_job.rb
+++ b/app/jobs/sync_zoho_emails_job.rb
@@ -36,7 +36,7 @@ class SyncZohoEmailsJob < ApplicationJob
       zoho_message_id: message_id,
       zoho_folder_id: folder_id,
       from_address: email_data["fromAddress"],
-      subject: email_data["subject"],
+      subject: email_data["subject"].presence || "(No Subject)",
       summary: email_data["summary"],
       body: body,
       received_at: Time.at(email_data["receivedTime"].to_i / 1000)

--- a/test/jobs/sync_zoho_emails_job_test.rb
+++ b/test/jobs/sync_zoho_emails_job_test.rb
@@ -195,6 +195,24 @@ class SyncZohoEmailsJobTest < ActiveJob::TestCase
     assert_match "ImageDisplay", email.body
   end
 
+  test "stores email with blank subject as '(No Subject)'" do
+    blank_subject_email = {
+      "messageId" => "msg_no_subject",
+      "fromAddress" => "newsletter@example.com",
+      "subject" => nil,
+      "summary" => "Email with no subject",
+      "receivedTime" => (1.hour.ago.to_f * 1000).to_i.to_s
+    }
+    @stub_zoho.define_singleton_method(:emails) { |folder_id:, limit:| [ blank_subject_email ] }
+
+    assert_difference "CachedEmail.count", 1 do
+      SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho)
+    end
+
+    email = CachedEmail.find_by(zoho_message_id: "msg_no_subject")
+    assert_equal "(No Subject)", email.subject
+  end
+
   test "continues syncing when individual email content fetch fails" do
     call_count = 0
     @stub_zoho.define_singleton_method(:email) do |folder_id:, message_id:|


### PR DESCRIPTION
## Root cause

`SyncZohoEmailsJob#sync_email` called `CachedEmail.create!` with `subject: email_data["subject"]`. Zoho emails can legitimately arrive with a nil or empty subject field. `CachedEmail` validates `presence: true` on subject, so any such email raised `ActiveRecord::RecordInvalid: Validation failed: Subject can't be blank` and crashed the entire job run.

This was happening 94 times over 2 days (Sentry issue [THENCF-W](https://seo-cahill.sentry.io/issues/THENCF-W), first seen 2026-07-17, last seen minutes before this fix).

## Fix

One-line change in `sync_email`: use `.presence || "(No Subject)"` as the subject fallback — standard email-client behaviour. No emails are silently dropped, and the validation is satisfied.

## Test

Added a test that feeds a nil-subject email through the job and asserts the stored record has `"(No Subject)"` as its subject. The test was red before the fix and green after. Full suite: 726 tests, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01PQjN6CdmhDPKABE3Tzh1Cv)_