### PR TITLE
Fix SyncZohoEmailsJob crash on emails with blank subject

### DIFF
--- a/app/models/cached_email.rb
+++ b/app/models/cached_email.rb
@@ -6,7 +6,6 @@ class CachedEmail < ApplicationRecord
 
   validates :zoho_message_id, presence: true, uniqueness: true
   validates :from_address, presence: true
-  validates :subject, presence: true
   validates :received_at, presence: true
 
   scope :recent, -> { where("received_at >= ?", 30.days.ago).order(received_at: :desc) }

--- a/db/migrate/20260720070957_allow_null_subject_on_cached_emails.rb
+++ b/db/migrate/20260720070957_allow_null_subject_on_cached_emails.rb
@@ -1,0 +1,5 @@
+class AllowNullSubjectOnCachedEmails < ActiveRecord::Migration[8.1]
+  def change
+    change_column_null :cached_emails, :subject, true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_07_03_165532) do
+ActiveRecord::Schema[8.1].define(version: 2026_07_20_070957) do
   create_table "_litestream_lock", id: false, force: :cascade do |t|
     t.integer "id"
   end
@@ -125,7 +125,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_07_03_165532) do
     t.string "from_address", null: false
     t.datetime "received_at", null: false
     t.integer "status", default: 0, null: false
-    t.string "subject", null: false
+    t.string "subject"
     t.text "summary"
     t.datetime "updated_at", null: false
     t.string "zoho_folder_id", null: false

--- a/test/jobs/sync_zoho_emails_job_test.rb
+++ b/test/jobs/sync_zoho_emails_job_test.rb
@@ -195,6 +195,42 @@ class SyncZohoEmailsJobTest < ActiveJob::TestCase
     assert_match "ImageDisplay", email.body
   end
 
+  test "syncs emails with blank subject without raising" do
+    @zoho_emails << {
+      "messageId" => "msg_003",
+      "fromAddress" => "newsletter@example.com",
+      "subject" => "",
+      "summary" => "Monthly update",
+      "receivedTime" => (30.minutes.ago.to_f * 1000).to_i.to_s
+    }
+
+    assert_difference "CachedEmail.count", 3 do
+      assert_nothing_raised { SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho) }
+    end
+
+    email = CachedEmail.find_by(zoho_message_id: "msg_003")
+    assert_not_nil email
+    assert_equal "", email.subject
+  end
+
+  test "syncs emails with nil subject without raising" do
+    @zoho_emails << {
+      "messageId" => "msg_004",
+      "fromAddress" => "sender@example.com",
+      "subject" => nil,
+      "summary" => "No subject email",
+      "receivedTime" => (15.minutes.ago.to_f * 1000).to_i.to_s
+    }
+
+    assert_difference "CachedEmail.count", 3 do
+      assert_nothing_raised { SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho) }
+    end
+
+    email = CachedEmail.find_by(zoho_message_id: "msg_004")
+    assert_not_nil email
+    assert_nil email.subject
+  end
+
   test "continues syncing when individual email content fetch fails" do
     call_count = 0
     @stub_zoho.define_singleton_method(:email) do |folder_id:, message_id:|

--- a/test/models/cached_email_test.rb
+++ b/test/models/cached_email_test.rb
@@ -53,15 +53,25 @@ class CachedEmailTest < ActiveSupport::TestCase
     assert_includes email.errors[:from_address], "can't be blank"
   end
 
-  test "requires subject" do
+  test "allows blank subject" do
     email = CachedEmail.new(
       zoho_message_id: "msg_123",
       zoho_folder_id: "folder_456",
       from_address: "sender@example.com",
       received_at: 1.hour.ago
     )
-    assert_not email.valid?
-    assert_includes email.errors[:subject], "can't be blank"
+    assert email.valid?, "CachedEmail should be valid without a subject"
+  end
+
+  test "allows nil subject" do
+    email = CachedEmail.new(
+      zoho_message_id: "msg_nil_subject",
+      zoho_folder_id: "folder_456",
+      from_address: "sender@example.com",
+      subject: nil,
+      received_at: 1.hour.ago
+    )
+    assert email.valid?
   end
 
   test "requires received_at" do


### PR DESCRIPTION
## Root cause

Sentry issue [THENCF-W](https://seo-cahill.sentry.io/issues/THENCF-W) — 142 occurrences over 3 days, still escalating.

`SyncZohoEmailsJob` iterates over emails from Zoho and calls `CachedEmail.create!` for each new message. When Zoho returns an email with a blank or nil subject, `create!` raises `ActiveRecord::RecordInvalid: Validation failed: Subject can't be blank` at `sync_zoho_emails_job.rb:35`. That exception is not rescued inside `sync_email`, so it propagates out of the `emails.each` block and aborts the entire sync batch — all emails after the blank-subject one are silently skipped.

The root cause is that `validates :subject, presence: true` on `CachedEmail` is too strict. Blank email subjects are valid per the email spec and do arrive from Zoho in practice.

## Changes

- **`app/models/cached_email.rb`** — remove `validates :subject, presence: true`. The `noise?` method already handles nil subject safely via `.to_s`, so no further model changes are needed.
- **`db/migrate/..._allow_null_subject_on_cached_emails.rb`** — drop the `NOT NULL` constraint from the `cached_emails.subject` column.
- **`test/jobs/sync_zoho_emails_job_test.rb`** — add two tests: blank string subject and nil subject both sync without raising.
- **`test/models/cached_email_test.rb`** — replace the "requires subject" assertion with "allows blank subject" and "allows nil subject" to reflect the corrected behaviour.

## Test plan

- [ ] `bin/rails test test/jobs/sync_zoho_emails_job_test.rb` — new tests pass
- [ ] `bin/rails test` — full suite green (728 runs, 0 failures, 0 errors)
- [ ] Deploy includes `bin/rails db:migrate` to apply the column constraint change

---
_Generated by [Claude Code](https://claude.ai/code/session_01MZ2mW9knFiS8BModrMQFrS)_