### PR TITLE
Fix SyncZohoEmailsJob crash on emails with blank subject

### DIFF
--- a/app/jobs/sync_zoho_emails_job.rb
+++ b/app/jobs/sync_zoho_emails_job.rb
@@ -36,7 +36,7 @@ class SyncZohoEmailsJob < ApplicationJob
       zoho_message_id: message_id,
       zoho_folder_id: folder_id,
       from_address: email_data["fromAddress"],
-      subject: email_data["subject"],
+      subject: email_data["subject"].presence || "(No Subject)",
       summary: email_data["summary"],
       body: body,
       received_at: Time.at(email_data["receivedTime"].to_i / 1000)

--- a/test/jobs/sync_zoho_emails_job_test.rb
+++ b/test/jobs/sync_zoho_emails_job_test.rb
@@ -195,6 +195,48 @@ class SyncZohoEmailsJobTest < ActiveJob::TestCase
     assert_match "ImageDisplay", email.body
   end
 
+  test "syncs email with blank subject using (No Subject) fallback" do
+    @zoho_emails = [
+      {
+        "messageId" => "msg_no_subject",
+        "fromAddress" => "sender@example.com",
+        "subject" => "",
+        "summary" => "A message with no subject",
+        "receivedTime" => (1.hour.ago.to_f * 1000).to_i.to_s
+      }
+    ]
+    zoho_emails = @zoho_emails
+    @stub_zoho.define_singleton_method(:emails) { |folder_id:, limit:| zoho_emails }
+
+    assert_difference "CachedEmail.count", 1 do
+      SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho)
+    end
+
+    email = CachedEmail.find_by(zoho_message_id: "msg_no_subject")
+    assert_equal "(No Subject)", email.subject
+  end
+
+  test "syncs email with nil subject using (No Subject) fallback" do
+    @zoho_emails = [
+      {
+        "messageId" => "msg_nil_subject",
+        "fromAddress" => "sender@example.com",
+        "subject" => nil,
+        "summary" => "A message with nil subject",
+        "receivedTime" => (1.hour.ago.to_f * 1000).to_i.to_s
+      }
+    ]
+    zoho_emails = @zoho_emails
+    @stub_zoho.define_singleton_method(:emails) { |folder_id:, limit:| zoho_emails }
+
+    assert_difference "CachedEmail.count", 1 do
+      SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho)
+    end
+
+    email = CachedEmail.find_by(zoho_message_id: "msg_nil_subject")
+    assert_equal "(No Subject)", email.subject
+  end
+
   test "continues syncing when individual email content fetch fails" do
     call_count = 0
     @stub_zoho.define_singleton_method(:email) do |folder_id:, message_id:|


### PR DESCRIPTION
## Root cause

Some Zoho emails arrive with a blank or nil `subject` field (e.g. automated messages, malformed senders). `SyncZohoEmailsJob#sync_email` was passing `email_data["subject"]` directly to `CachedEmail.create!`, which raises `ActiveRecord::RecordInvalid` because the model validates `subject: presence: true`. With 190 occurrences over 3 days this was causing the entire sync job to abort whenever one of these emails appeared in the inbox.

Sentry issue: https://seo-cahill.sentry.io/issues/THENCF-W

## Fix

One-line change in `sync_email`: fall back to `"(No Subject)"` when the subject is blank — the standard convention used by every email client:

```ruby
subject: email_data["subject"].presence || "(No Subject)",
```

## Tests

Two new test cases added to `SyncZohoEmailsJobTest`:
- `syncs email with blank subject using (No Subject) fallback`
- `syncs email with nil subject using (No Subject) fallback`

Both tests previously reproduced the exact `ActiveRecord::RecordInvalid` error from Sentry. Full suite: 727 tests, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01RkNa5QzmRyHxJFiodsFSuD)_