### PR TITLE
Fix SyncZohoEmailsJob crash on emails with blank subject

### DIFF
--- a/app/jobs/sync_zoho_emails_job.rb
+++ b/app/jobs/sync_zoho_emails_job.rb
@@ -36,7 +36,7 @@ class SyncZohoEmailsJob < ApplicationJob
       zoho_message_id: message_id,
       zoho_folder_id: folder_id,
       from_address: email_data["fromAddress"],
-      subject: email_data["subject"],
+      subject: email_data["subject"].presence || "(No Subject)",
       summary: email_data["summary"],
       body: body,
       received_at: Time.at(email_data["receivedTime"].to_i / 1000)

--- a/test/jobs/sync_zoho_emails_job_test.rb
+++ b/test/jobs/sync_zoho_emails_job_test.rb
@@ -215,4 +215,24 @@ class SyncZohoEmailsJobTest < ActiveJob::TestCase
     email2 = CachedEmail.find_by(zoho_message_id: "msg_002")
     assert_equal "<p>Email body for msg_002</p>", email2.body
   end
+
+  test "syncs emails with blank subject using fallback" do
+    @zoho_emails << {
+      "messageId" => "msg_003",
+      "fromAddress" => "sender@example.com",
+      "subject" => nil,
+      "summary" => "No subject email",
+      "receivedTime" => (30.minutes.ago.to_f * 1000).to_i.to_s
+    }
+
+    zoho_emails = @zoho_emails
+    @stub_zoho.define_singleton_method(:emails) { |folder_id:, limit:| zoho_emails }
+
+    assert_difference "CachedEmail.count", 3 do
+      SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho)
+    end
+
+    email = CachedEmail.find_by(zoho_message_id: "msg_003")
+    assert_equal "(No Subject)", email.subject
+  end
 end


### PR DESCRIPTION
## Root cause

Zoho's API returns some emails with a `nil` or empty `subject` field (e.g. emails sent without a subject line). `SyncZohoEmailsJob#sync_email` was passing `email_data["subject"]` directly to `CachedEmail.create!`, which validates `subject` for presence. This raised `ActiveRecord::RecordInvalid`, causing the exception to propagate up through `perform` uncaught (it's not a network/API error, so the rescue clause didn't catch it). The entire batch of emails was lost on every affected run.

Sentry issue: [THENCF-W](https://seo-cahill.sentry.io/issues/THENCF-W) — 430 occurrences over 8 days, ongoing.

## Fix

Use `.presence || "(No Subject)"` as a fallback in the job (one-line change). This matches the convention email clients use for subjectless email and satisfies the model validation, so the email is synced rather than dropped.

## Tests

Added a test case (`syncs emails with blank subject using fallback`) that pushes a `nil`-subject email through the job and asserts:
- The email is created (no exception)
- The subject is stored as `"(No Subject)"`

Full suite: 726 tests, 0 failures, 0 errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01YbZdqVMSXkaaczzt3inc2x)_