### PR TITLE
Fix blank subject crash in SyncZohoEmailsJob

### DIFF
--- a/app/jobs/sync_zoho_emails_job.rb
+++ b/app/jobs/sync_zoho_emails_job.rb
@@ -36,7 +36,7 @@ class SyncZohoEmailsJob < ApplicationJob
       zoho_message_id: message_id,
       zoho_folder_id: folder_id,
       from_address: email_data["fromAddress"],
-      subject: email_data["subject"],
+      subject: email_data["subject"].presence || "(No Subject)",
       summary: email_data["summary"],
       body: body,
       received_at: Time.at(email_data["receivedTime"].to_i / 1000)

--- a/test/jobs/sync_zoho_emails_job_test.rb
+++ b/test/jobs/sync_zoho_emails_job_test.rb
@@ -195,6 +195,18 @@ class SyncZohoEmailsJobTest < ActiveJob::TestCase
     assert_match "ImageDisplay", email.body
   end
 
+  test "syncs emails with blank subject using (No Subject) fallback" do
+    @zoho_emails[0]["subject"] = nil
+    @zoho_emails[1]["subject"] = ""
+
+    assert_difference "CachedEmail.count", 2 do
+      SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho)
+    end
+
+    assert_equal "(No Subject)", CachedEmail.find_by(zoho_message_id: "msg_001").subject
+    assert_equal "(No Subject)", CachedEmail.find_by(zoho_message_id: "msg_002").subject
+  end
+
   test "continues syncing when individual email content fetch fails" do
     call_count = 0
     @stub_zoho.define_singleton_method(:email) do |folder_id:, message_id:|


### PR DESCRIPTION
## Root cause

Zoho emails with no subject line return `nil` or `""` for the `"subject"` key in the API payload. `SyncZohoEmailsJob#sync_email` passed that value directly to `CachedEmail.create!`, which validates `subject: presence: true`. This caused an unhandled `ActiveRecord::RecordInvalid` exception, silently dropping the email from the sync.

Sentry issue: https://seo-cahill.sentry.io/issues/THENCF-W — 478 occurrences since 2026-07-17, still firing every hour.

## Fix

Fall back to `"(No Subject)"` (standard email convention) when the Zoho payload has a blank subject:

```ruby
subject: email_data["subject"].presence || "(No Subject)",
```

This is a one-line change in the job. The model validation stays intact — it correctly enforces that we never store an empty string.

## Tests

Added a test that sets `subject` to `nil` and `""` on the two stub emails and asserts:
1. Both emails are created (no exception)
2. Both stored with `"(No Subject)"`

Full suite: 726 runs, 0 failures.

---
_Generated by [Claude Code](https://claude.ai/code/session_01A57YtPKaSGcBHpx1vzbDKi)_