### PR TITLE
Fix SyncZohoEmailsJob crash on emails with blank subject

### DIFF
--- a/app/jobs/sync_zoho_emails_job.rb
+++ b/app/jobs/sync_zoho_emails_job.rb
@@ -36,7 +36,7 @@ class SyncZohoEmailsJob < ApplicationJob
       zoho_message_id: message_id,
       zoho_folder_id: folder_id,
       from_address: email_data["fromAddress"],
-      subject: email_data["subject"],
+      subject: email_data["subject"].presence || "(No Subject)",
       summary: email_data["summary"],
       body: body,
       received_at: Time.at(email_data["receivedTime"].to_i / 1000)

--- a/test/jobs/sync_zoho_emails_job_test.rb
+++ b/test/jobs/sync_zoho_emails_job_test.rb
@@ -195,6 +195,42 @@ class SyncZohoEmailsJobTest < ActiveJob::TestCase
     assert_match "ImageDisplay", email.body
   end
 
+  test "syncs emails with nil subject using no-subject fallback" do
+    @zoho_emails << {
+      "messageId" => "msg_003",
+      "fromAddress" => "sender@example.com",
+      "subject" => nil,
+      "summary" => "Email with no subject",
+      "receivedTime" => (30.minutes.ago.to_f * 1000).to_i.to_s
+    }
+
+    assert_difference "CachedEmail.count", 3 do
+      SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho)
+    end
+
+    email = CachedEmail.find_by(zoho_message_id: "msg_003")
+    assert_not_nil email
+    assert_equal "(No Subject)", email.subject
+  end
+
+  test "syncs emails with blank subject using no-subject fallback" do
+    @zoho_emails << {
+      "messageId" => "msg_003",
+      "fromAddress" => "sender@example.com",
+      "subject" => "",
+      "summary" => "Email with blank subject",
+      "receivedTime" => (30.minutes.ago.to_f * 1000).to_i.to_s
+    }
+
+    assert_difference "CachedEmail.count", 3 do
+      SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho)
+    end
+
+    email = CachedEmail.find_by(zoho_message_id: "msg_003")
+    assert_not_nil email
+    assert_equal "(No Subject)", email.subject
+  end
+
   test "continues syncing when individual email content fetch fails" do
     call_count = 0
     @stub_zoho.define_singleton_method(:email) do |folder_id:, message_id:|


### PR DESCRIPTION
## Root cause

`SyncZohoEmailsJob#sync_email` passed `email_data["subject"]` directly to `CachedEmail.create!`. Some Zoho emails have a nil or empty subject field. Because `CachedEmail` validates `subject` presence, this raised `ActiveRecord::RecordInvalid` on every such message — aborting sync of that email and all subsequent ones in the batch.

Sentry issue: [THENCF-W](https://seo-cahill.sentry.io/issues/THENCF-W) — 526 occurrences, ongoing since 2026-07-17.

## Fix

One-line change in `sync_email`: fall back to `"(No Subject)"` when the Zoho payload has a blank subject, consistent with standard email client behaviour:

```ruby
subject: email_data["subject"].presence || "(No Subject)",
```

## Tests

Two new test cases cover nil and blank subject inputs. Full suite: 727 tests, 0 failures, 0 errors.

---
_Generated by [Claude Code](https://claude.ai/code/session_01MwSJ7e9ChYsLFZkGKQQf94)_