### PR TITLE
Fix SyncZohoEmailsJob crash on emails with blank subject

### DIFF
--- a/app/models/cached_email.rb
+++ b/app/models/cached_email.rb
@@ -6,7 +6,6 @@ class CachedEmail < ApplicationRecord
 
   validates :zoho_message_id, presence: true, uniqueness: true
   validates :from_address, presence: true
-  validates :subject, presence: true
   validates :received_at, presence: true
 
   scope :recent, -> { where("received_at >= ?", 30.days.ago).order(received_at: :desc) }

--- a/test/jobs/sync_zoho_emails_job_test.rb
+++ b/test/jobs/sync_zoho_emails_job_test.rb
@@ -215,4 +215,24 @@ class SyncZohoEmailsJobTest < ActiveJob::TestCase
     email2 = CachedEmail.find_by(zoho_message_id: "msg_002")
     assert_equal "<p>Email body for msg_002</p>", email2.body
   end
+
+  test "syncs emails with blank subject" do
+    @stub_zoho.define_singleton_method(:emails) do |folder_id:, limit:|
+      [ {
+        "messageId" => "msg_no_subject",
+        "fromAddress" => "sender@example.com",
+        "subject" => "",
+        "summary" => "Some summary",
+        "receivedTime" => (1.hour.ago.to_f * 1000).to_i.to_s
+      } ]
+    end
+
+    assert_difference "CachedEmail.count", 1 do
+      SyncZohoEmailsJob.perform_now(zoho_service: @stub_zoho)
+    end
+
+    email = CachedEmail.find_by(zoho_message_id: "msg_no_subject")
+    assert_not_nil email
+    assert_equal "", email.subject
+  end
 end

--- a/test/models/cached_email_test.rb
+++ b/test/models/cached_email_test.rb
@@ -53,15 +53,15 @@ class CachedEmailTest < ActiveSupport::TestCase
     assert_includes email.errors[:from_address], "can't be blank"
   end
 
-  test "requires subject" do
+  test "allows blank subject" do
     email = CachedEmail.new(
       zoho_message_id: "msg_123",
       zoho_folder_id: "folder_456",
       from_address: "sender@example.com",
       received_at: 1.hour.ago
     )
-    assert_not email.valid?
-    assert_includes email.errors[:subject], "can't be blank"
+    assert email.valid?
+    assert_empty email.errors[:subject]
   end
 
   test "requires received_at" do


### PR DESCRIPTION
## Root cause

`CachedEmail` had `validates :subject, presence: true`, but Zoho can return emails with a blank subject line. `SyncZohoEmailsJob#sync_email` calls `CachedEmail.create!` with whatever subject Zoho provides, so any subjectless email caused:

```
ActiveRecord::RecordInvalid: Validation failed: Subject can't be blank
```

This has been firing 574 times since 2026-07-17 (Sentry issue [THENCF-W](https://seo-cahill.sentry.io/issues/THENCF-W)).

## Fix

Remove the `presence: true` validation from `CachedEmail#subject`. A blank subject is a perfectly valid email — the validation was over-constraining the model. Nothing in `CachedEmail`'s own logic depends on subject being non-nil; `noise?` and `to_admin_todo_attrs` both handle nil/blank gracefully.

## Changes

- `app/models/cached_email.rb` — remove subject presence validation
- `test/models/cached_email_test.rb` — update `test_requires_subject` → `test_allows_blank_subject` to reflect correct behaviour
- `test/jobs/sync_zoho_emails_job_test.rb` — add a test that reproduces the Sentry failure (email with blank subject must be persisted)

## Test plan

- [x] New job test `syncs emails with blank subject` was failing before the fix, passes after
- [x] Full suite: 726 runs, 0 failures, 0 errors

---
_Generated by [Claude Code](https://claude.ai/code/session_011BzJEoug9oUvh8zJ1DUmbm)_